### PR TITLE
fix(mappings): don't type unknown mappings as null

### DIFF
--- a/lib/util/feelUtility.js
+++ b/lib/util/feelUtility.js
@@ -226,8 +226,7 @@ function toUnifiedFormat(variables) {
 
     if (!variable) {
       result.push({
-        name: key,
-        type: 'Null'
+        name: key
       });
       continue;
     }
@@ -269,10 +268,6 @@ function getType(variable) {
 
   if (variable.atomicValue) {
     return capitalize(typeof variable.atomicValue);
-  }
-
-  if (variable.atomicValue === null) {
-    return 'Null';
   }
 
   return '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "karma-webpack": "^5.0.0",
         "mocha": "^10.1.0",
         "mocha-test-container-support": "^0.2.0",
-        "puppeteer": "^19.3.0",
+        "puppeteer": "^19.7.5",
         "raw-loader": "^4.0.2",
         "webpack": "^5.75.0",
         "zeebe-bpmn-moddle": "^0.16.0"
@@ -1761,6 +1761,18 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.5.tgz",
+      "integrity": "sha512-rkav9YzRfAshSTG3wNXF7P7yNiI29QAo1xBXElPoCoSQR5n20q3cOyVhDv6S7+GlF/CJ/emUxlQiR0xOPurkGg==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "3.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
@@ -1894,9 +1906,9 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
-      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.0.tgz",
+      "integrity": "sha512-0tLZ9URlPGU7JsKq0DQOQ3FoRsYX8xDZ7xMiATQfaiGMz7EHowNkbU9u1coAOmnh9p/1ySpm0RB3JNWRXM5GCg==",
       "dev": true,
       "dependencies": {
         "import-fresh": "^3.2.1",
@@ -1906,6 +1918,9 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
       }
     },
     "node_modules/cosmiconfig/node_modules/argparse": {
@@ -2086,9 +2101,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1082910",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
-      "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww==",
+      "version": "0.0.1094867",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz",
+      "integrity": "sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ==",
       "dev": true
     },
     "node_modules/di": {
@@ -4607,6 +4622,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "dev": true
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -5234,6 +5264,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-scurry": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.2.tgz",
+      "integrity": "sha512-J6MQNh56h6eHFY3vsQ+Lq+zKPwn71POieutmVt2leU8W+zz8HVIdJyn3I3Zs6IKbIQtuKXirVjTBFNBcbFO44Q==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^7.14.1",
+        "minipass": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -5372,41 +5427,128 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.3.tgz",
-      "integrity": "sha512-K03xTtGDwS6cBXX/EoqoZxglCUKcX2SLIl92fMnGMRjYpPGXoAV2yKEh3QXmXzKqfZXd8TxjjFww+tEttWv8kw==",
+      "version": "19.7.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.7.5.tgz",
+      "integrity": "sha512-UqD8K+yaZa6/hwzP54AATCiHrEYGGxzQcse9cZzrtsVGd8wT0llCdYhsBp8n+zvnb1ofY0YFgI3TYZ/MiX5uXQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "cosmiconfig": "8.0.0",
+        "cosmiconfig": "8.1.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.6.3"
-      },
-      "engines": {
-        "node": ">=14.1.0"
+        "puppeteer-core": "19.7.5"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.3.tgz",
-      "integrity": "sha512-8MbhioSlkDaHkmolpQf9Z7ui7jplFfOFTnN8d5kPsCazRRTNIH6/bVxPskn0v5Gh9oqOBlknw0eHH0/OBQAxpQ==",
+      "version": "19.7.5",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.7.5.tgz",
+      "integrity": "sha512-EJuNha+SxPfaYFbkoWU80H3Wb1SiQH5fFyb2xdbWda0ziax5mhV63UMlqNfPeTDIWarwtR4OIcq/9VqY8HPOsg==",
       "dev": true,
       "dependencies": {
+        "chromium-bidi": "0.4.5",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1082910",
+        "devtools-protocol": "0.0.1094867",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
+        "rimraf": "4.4.0",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.11.0"
+        "ws": "8.12.1"
       },
       "engines": {
-        "node": ">=14.1.0"
+        "node": ">=14.14.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/glob": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.1.tgz",
+      "integrity": "sha512-qERvJb7IGsnkx6YYmaaGvDpf77c951hICMdWaFXyH3PlVob8sbPJJyJX0kWkiCWyXUzoy9UOTNjGg0RbD8bYIw==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^7.4.1",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/minimatch": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
+      "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/rimraf": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.0.tgz",
+      "integrity": "sha512-X36S+qpCUR0HjXlkDe4NAOhS//aHH0Z+h8Ckf2auGJk3PTnx5rLmrHkwNdbVQuCSUhOyFrlRvFEllZOYE+yZGQ==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/qjobs": {
@@ -5537,9 +5679,9 @@
       "dev": true
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -8265,6 +8407,15 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true
     },
+    "chromium-bidi": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.5.tgz",
+      "integrity": "sha512-rkav9YzRfAshSTG3wNXF7P7yNiI29QAo1xBXElPoCoSQR5n20q3cOyVhDv6S7+GlF/CJ/emUxlQiR0xOPurkGg==",
+      "dev": true,
+      "requires": {
+        "mitt": "3.0.0"
+      }
+    },
     "classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
@@ -8385,9 +8536,9 @@
       }
     },
     "cosmiconfig": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
-      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.0.tgz",
+      "integrity": "sha512-0tLZ9URlPGU7JsKq0DQOQ3FoRsYX8xDZ7xMiATQfaiGMz7EHowNkbU9u1coAOmnh9p/1ySpm0RB3JNWRXM5GCg==",
       "dev": true,
       "requires": {
         "import-fresh": "^3.2.1",
@@ -8525,9 +8676,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1082910",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
-      "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww==",
+      "version": "0.0.1094867",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz",
+      "integrity": "sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ==",
       "dev": true
     },
     "di": {
@@ -10424,6 +10575,18 @@
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
+    "minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "dev": true
+    },
+    "mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "dev": true
+    },
     "mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -10888,6 +11051,24 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-scurry": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.2.tgz",
+      "integrity": "sha512-J6MQNh56h6eHFY3vsQ+Lq+zKPwn71POieutmVt2leU8W+zz8HVIdJyn3I3Zs6IKbIQtuKXirVjTBFNBcbFO44Q==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^7.14.1",
+        "minipass": "^4.0.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "dev": true
+        }
+      }
+    },
     "path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -10996,34 +11177,83 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.3.tgz",
-      "integrity": "sha512-K03xTtGDwS6cBXX/EoqoZxglCUKcX2SLIl92fMnGMRjYpPGXoAV2yKEh3QXmXzKqfZXd8TxjjFww+tEttWv8kw==",
+      "version": "19.7.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.7.5.tgz",
+      "integrity": "sha512-UqD8K+yaZa6/hwzP54AATCiHrEYGGxzQcse9cZzrtsVGd8wT0llCdYhsBp8n+zvnb1ofY0YFgI3TYZ/MiX5uXQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "8.0.0",
+        "cosmiconfig": "8.1.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.6.3"
+        "puppeteer-core": "19.7.5"
       }
     },
     "puppeteer-core": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.3.tgz",
-      "integrity": "sha512-8MbhioSlkDaHkmolpQf9Z7ui7jplFfOFTnN8d5kPsCazRRTNIH6/bVxPskn0v5Gh9oqOBlknw0eHH0/OBQAxpQ==",
+      "version": "19.7.5",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.7.5.tgz",
+      "integrity": "sha512-EJuNha+SxPfaYFbkoWU80H3Wb1SiQH5fFyb2xdbWda0ziax5mhV63UMlqNfPeTDIWarwtR4OIcq/9VqY8HPOsg==",
       "dev": true,
       "requires": {
+        "chromium-bidi": "0.4.5",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1082910",
+        "devtools-protocol": "0.0.1094867",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
+        "rimraf": "4.4.0",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.11.0"
+        "ws": "8.12.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.1.tgz",
+          "integrity": "sha512-qERvJb7IGsnkx6YYmaaGvDpf77c951hICMdWaFXyH3PlVob8sbPJJyJX0kWkiCWyXUzoy9UOTNjGg0RbD8bYIw==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "minimatch": "^7.4.1",
+            "minipass": "^4.2.4",
+            "path-scurry": "^1.6.1"
+          }
+        },
+        "minimatch": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
+          "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.0.tgz",
+          "integrity": "sha512-X36S+qpCUR0HjXlkDe4NAOhS//aHH0Z+h8Ckf2auGJk3PTnx5rLmrHkwNdbVQuCSUhOyFrlRvFEllZOYE+yZGQ==",
+          "dev": true,
+          "requires": {
+            "glob": "^9.2.0"
+          }
+        },
+        "ws": {
+          "version": "8.12.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+          "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "qjobs": {
@@ -11110,9 +11340,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@bpmn-io/properties-panel": "^1.3.1",
         "bpmn-js": "11.1.0",
-        "bpmn-js-properties-panel": "github:bpmn-io/bpmn-js-properties-panel#2771cc6f3897882e962363d9b7c0a0e029b2fae8",
+        "bpmn-js-properties-panel": "^1.19.1",
         "camunda-bpmn-js-behaviors": "^0.4.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.3.7",
@@ -379,13 +379,13 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.11.0.tgz",
-      "integrity": "sha512-4eZCPLuWf1N4lL8jIKZjWgwLJ2IUTgkQ4VDnfbDiSvjGJqHaLA4XBcC5smvb8Q/MqsJFxWZumolJJb1h7gt39Q==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.13.0.tgz",
+      "integrity": "sha512-eu2S2lXRxfbGpZk0JiB7Q+TzKm1+1hTsDJJEw7+AAvW8woY+URIz8qOaRB/j/q/V9SrijP7n78dzW41Eurrf6w==",
       "dev": true,
       "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.10.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.6.0",
+        "@camunda/element-templates-json-schema": "^0.12.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.8.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.0.0"
       }
@@ -452,15 +452,15 @@
       }
     },
     "node_modules/@camunda/element-templates-json-schema": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.10.1.tgz",
-      "integrity": "sha512-sw8RNecjQgY7tX26PMLRJGNX/2QCnlwCvZfxQWh606qlJZsLbpvEbvfgIGCRoYlHYTlsP6PxVcWYx5LPo7yisg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.12.0.tgz",
+      "integrity": "sha512-f5r/Xe0KgtSl+dG7TQVEATP70pGNMEn3Od8DVBpLXDgMiJWbQ9XR2XNlsao0XEoCu0AW0veLUD5/ItAEt0/a1A==",
       "dev": true
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.6.0.tgz",
-      "integrity": "sha512-qawIFM52lp1hW2vWrHaX8ywguZsp2olE0DRTHUY+KWH5GwszZwGWECP3tji1KVih2TasQyf28kcQVh8TeQ6dAg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.8.0.tgz",
+      "integrity": "sha512-KwGFOQrgROmqip+yyxgvT727b2JB1WQh72Y81AKdX+jEt417eE92mNP2FjhmDcbHmqLJDxzh9Ic9turZQGiE7A==",
       "dev": true
     },
     "node_modules/@codemirror/autocomplete": {
@@ -1460,13 +1460,12 @@
       }
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "1.16.0",
-      "resolved": "git+ssh://git@github.com/bpmn-io/bpmn-js-properties-panel.git#2771cc6f3897882e962363d9b7c0a0e029b2fae8",
-      "integrity": "sha512-x2rw05Zwkgbrz0miZrUxYFf8J47ND89zsCnsioqsuydXgU5HPBROjjnG6v5X4RrdXiA4T27W4BDQ8mef97vFvA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.19.1.tgz",
+      "integrity": "sha512-szwNQCCmHLxc3HsZ76gI7NB8TL1gQ/8s8PTmeZ8jqOlQBg98aIsh1KxHGn2srm9TrJJU4IY2sC2jx1MesvHzxQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^0.11.0",
+        "@bpmn-io/element-templates-validator": "^0.13.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",
         "array-move": "^3.0.1",
         "classnames": "^2.3.1",
@@ -7280,13 +7279,13 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.11.0.tgz",
-      "integrity": "sha512-4eZCPLuWf1N4lL8jIKZjWgwLJ2IUTgkQ4VDnfbDiSvjGJqHaLA4XBcC5smvb8Q/MqsJFxWZumolJJb1h7gt39Q==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.13.0.tgz",
+      "integrity": "sha512-eu2S2lXRxfbGpZk0JiB7Q+TzKm1+1hTsDJJEw7+AAvW8woY+URIz8qOaRB/j/q/V9SrijP7n78dzW41Eurrf6w==",
       "dev": true,
       "requires": {
-        "@camunda/element-templates-json-schema": "^0.10.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.6.0",
+        "@camunda/element-templates-json-schema": "^0.12.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.8.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.0.0"
       }
@@ -7355,15 +7354,15 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.10.1.tgz",
-      "integrity": "sha512-sw8RNecjQgY7tX26PMLRJGNX/2QCnlwCvZfxQWh606qlJZsLbpvEbvfgIGCRoYlHYTlsP6PxVcWYx5LPo7yisg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.12.0.tgz",
+      "integrity": "sha512-f5r/Xe0KgtSl+dG7TQVEATP70pGNMEn3Od8DVBpLXDgMiJWbQ9XR2XNlsao0XEoCu0AW0veLUD5/ItAEt0/a1A==",
       "dev": true
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.6.0.tgz",
-      "integrity": "sha512-qawIFM52lp1hW2vWrHaX8ywguZsp2olE0DRTHUY+KWH5GwszZwGWECP3tji1KVih2TasQyf28kcQVh8TeQ6dAg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.8.0.tgz",
+      "integrity": "sha512-KwGFOQrgROmqip+yyxgvT727b2JB1WQh72Y81AKdX+jEt417eE92mNP2FjhmDcbHmqLJDxzh9Ic9turZQGiE7A==",
       "dev": true
     },
     "@codemirror/autocomplete": {
@@ -8200,12 +8199,12 @@
       }
     },
     "bpmn-js-properties-panel": {
-      "version": "git+ssh://git@github.com/bpmn-io/bpmn-js-properties-panel.git#2771cc6f3897882e962363d9b7c0a0e029b2fae8",
-      "integrity": "sha512-x2rw05Zwkgbrz0miZrUxYFf8J47ND89zsCnsioqsuydXgU5HPBROjjnG6v5X4RrdXiA4T27W4BDQ8mef97vFvA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.19.1.tgz",
+      "integrity": "sha512-szwNQCCmHLxc3HsZ76gI7NB8TL1gQ/8s8PTmeZ8jqOlQBg98aIsh1KxHGn2srm9TrJJU4IY2sC2jx1MesvHzxQ==",
       "dev": true,
-      "from": "bpmn-js-properties-panel@github:bpmn-io/bpmn-js-properties-panel#2771cc6f3897882e962363d9b7c0a0e029b2fae8",
       "requires": {
-        "@bpmn-io/element-templates-validator": "^0.11.0",
+        "@bpmn-io/element-templates-validator": "^0.13.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",
         "array-move": "^3.0.1",
         "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "@bpmn-io/properties-panel": "^1.3.1",
-    "bpmn-js-properties-panel": "github:bpmn-io/bpmn-js-properties-panel#2771cc6f3897882e962363d9b7c0a0e029b2fae8",
     "bpmn-js": "11.1.0",
+    "bpmn-js-properties-panel": "github:bpmn-io/bpmn-js-properties-panel#2771cc6f3897882e962363d9b7c0a0e029b2fae8",
     "camunda-bpmn-js-behaviors": "^0.4.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.3.7",
@@ -39,7 +39,7 @@
     "karma-webpack": "^5.0.0",
     "mocha": "^10.1.0",
     "mocha-test-container-support": "^0.2.0",
-    "puppeteer": "^19.3.0",
+    "puppeteer": "^19.7.5",
     "raw-loader": "^4.0.2",
     "webpack": "^5.75.0",
     "zeebe-bpmn-moddle": "^0.16.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@bpmn-io/properties-panel": "^1.3.1",
     "bpmn-js": "11.1.0",
-    "bpmn-js-properties-panel": "github:bpmn-io/bpmn-js-properties-panel#2771cc6f3897882e962363d9b7c0a0e029b2fae8",
+    "bpmn-js-properties-panel": "^1.19.1",
     "camunda-bpmn-js-behaviors": "^0.4.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.3.7",

--- a/test/spec/zeebe/Mappings.spec.js
+++ b/test/spec/zeebe/Mappings.spec.js
@@ -8,8 +8,6 @@ import { bootstrapModeler, inject } from 'test/TestHelper';
 
 import { ZeebeVariableResolverModule } from 'lib/';
 
-// import simpleXML from '../fixtures/zeebe/simple.bpmn';
-
 import chainedMappingsXML from 'test/fixtures/zeebe/mappings/chained-mappings.bpmn';
 import primitivesXML from 'test/fixtures/zeebe/mappings/primitives.bpmn';
 import mergingXML from 'test/fixtures/zeebe/mappings/merging.bpmn';
@@ -93,7 +91,7 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
             { name: 'string', type: 'String', info: 'foo', entries: [] },
             { name: 'number', type: 'Number', info: '1', entries: [] },
             { name: 'boolean', type: 'Boolean', info: 'true', entries: [] },
-            { name: 'null', type: 'Null', entries: [] },
+            { name: 'null', type: '', entries: [] },
           ]
         }
       ]);
@@ -118,7 +116,7 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
             { name: 'string', detail: 'String', info: 'foo', entries: [] },
             { name: 'number', detail: 'Number', info: '1', entries: [] },
             { name: 'boolean', detail: 'Boolean', info: 'true', entries: [] },
-            { name: 'null', detail: 'Null', entries: [] },
+            { name: 'null', detail: '', entries: [] },
           ]
         }
       ]);
@@ -261,7 +259,7 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
         },
         {
           name: 'invalidMapping',
-          type: 'Null',
+          type: '',
           info: ''
         }
       ]);


### PR DESCRIPTION
closes #10 

We should not force the user to add external data sources, so `null` should be instead be handled as `undefined/any` and therefore not show any specific type.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
