### PR TITLE
fix: use branch with build artifacts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^0.8.0",
         "@lezer/common": "^1.0.2",
-        "lezer-feel": "github:marstamm/lezer-feel#decouple-context-format",
+        "lezer-feel": "github:marstamm/lezer-feel#decouple-context-format-build",
         "min-dash": "^4.0.0"
       },
       "devDependencies": {
@@ -4307,7 +4307,7 @@
     },
     "node_modules/lezer-feel": {
       "version": "0.16.2",
-      "resolved": "git+ssh://git@github.com/marstamm/lezer-feel.git#26fefead81b1dfb6a1550f739d748bb664d6ab39",
+      "resolved": "git+ssh://git@github.com/marstamm/lezer-feel.git#a0343b6ecbc05b4de28e6da353889f4718c8946f",
       "integrity": "sha512-hr7Tf28gvflA7mpB1WILasEUyC4JT4FPum6iJK/uyuluykJnDxRF0/XjqjV7FHJS3cuFanxYIh4/18p7kiu0gA==",
       "license": "MIT",
       "dependencies": {
@@ -10191,9 +10191,9 @@
       }
     },
     "lezer-feel": {
-      "version": "git+ssh://git@github.com/marstamm/lezer-feel.git#26fefead81b1dfb6a1550f739d748bb664d6ab39",
+      "version": "git+ssh://git@github.com/marstamm/lezer-feel.git#a0343b6ecbc05b4de28e6da353889f4718c8946f",
       "integrity": "sha512-hr7Tf28gvflA7mpB1WILasEUyC4JT4FPum6iJK/uyuluykJnDxRF0/XjqjV7FHJS3cuFanxYIh4/18p7kiu0gA==",
-      "from": "lezer-feel@github:marstamm/lezer-feel#decouple-context-format",
+      "from": "lezer-feel@github:marstamm/lezer-feel#decouple-context-format-build",
       "requires": {
         "@lezer/highlight": "^1.1.2",
         "@lezer/lr": "^1.2.5"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bpmn-io/extract-process-variables": "^0.8.0",
     "@lezer/common": "^1.0.2",
-    "lezer-feel": "github:marstamm/lezer-feel#decouple-context-format",
+    "lezer-feel": "github:marstamm/lezer-feel#decouple-context-format-build",
     "min-dash": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
this allows the package to be consumed by yarn@1 by adding [build artifacts to the branch](https://github.com/marstamm/lezer-feel/tree/a0343b6ecbc05b4de28e6da353889f4718c8946f/dist)

In the short/mid-term, we want to release the changes to lezer-feel, so this workaround will not be needed for long
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
