### PR TITLE
fix: missing context script task

### DIFF
--- a/lib/zeebe/VariableResolver.js
+++ b/lib/zeebe/VariableResolver.js
@@ -1,6 +1,6 @@
 import { getProcessVariables } from '@bpmn-io/extract-process-variables/zeebe';
 import { BaseVariableResolver } from '../base/VariableResolver';
-import { parseIoMappings } from './util/feelUtility';
+import { parseVariables } from './util/feelUtility';
 import {
   getBusinessObject,
   is
@@ -18,7 +18,7 @@ export default class ZeebeVariableResolver extends BaseVariableResolver {
     super(eventBus, bpmnjs);
     this._baseExtractor = getProcessVariables;
 
-    eventBus.on('variableResolver.parseVariables', HIGH_PRIORITY, this._resolveIoMappings);
+    eventBus.on('variableResolver.parseVariables', HIGH_PRIORITY, this._resolveVariables);
   }
 
   async getVariablesForElement(element, moddleElement) {
@@ -94,21 +94,21 @@ export default class ZeebeVariableResolver extends BaseVariableResolver {
   }
 
   /**
-   * Parsed the variables that have io-mappings and resolves the variable schema to kept the
+   * Parsed the variables and resolves the variable schema to kept the
    * variable schema throughout the process.
    *
    * @param {Event} e
    * @param {Object} context
    * @param {Array<ProcessVariable>} context.variables
    */
-  _resolveIoMappings(e, context) {
+  _resolveVariables(e, context) {
     const rawVariables = context.variables;
 
     const mappedVariables = {};
 
     for (const key in rawVariables) {
       const variables = rawVariables[key];
-      const newVariables = parseIoMappings(variables);
+      const newVariables = parseVariables(variables);
 
       mappedVariables[key] = [ ...variables, ...newVariables ];
     }

--- a/lib/zeebe/util/feelUtility.js
+++ b/lib/zeebe/util/feelUtility.js
@@ -7,13 +7,12 @@ import { EntriesContext } from './VariableContext';
 import { getExtensionElementsList } from '../../base/util/ExtensionElementsUtil';
 import { getParents } from '../../base/util/scopeUtil';
 
-
-export function parseIoMappings(variables) {
+export function parseVariables(variables) {
 
   const variablesToResolve = [];
 
-  // Step 1 - Parse all io mappings and populate all that don't have references
-  // to other variables io-mappings
+  // Step 1 - Parse all variables and populate all that don't have references
+  // to other variables
   variables.forEach(variable => {
     variable.origin.forEach(origin => {
       const expressionDetails = getExpressionDetails(variable, origin);

--- a/lib/zeebe/util/feelUtility.js
+++ b/lib/zeebe/util/feelUtility.js
@@ -159,6 +159,28 @@ export function getResultContext(expression, variables = {}) {
  * @returns {{ expression: String, unresolved: Array<String> }}}
  */
 function getExpressionDetails(variable, origin) {
+  const expression = getIoExpression(variable, origin) || getScriptExpression(variable, origin);
+
+  if (!expression) {
+    return;
+  }
+
+  const result = getResultContext(expression);
+
+  const unresolved = findUnresolvedVariables(result) ;
+
+  return { expression, unresolved };
+}
+
+/**
+ * Given a Variable and a specific origin, return the mapping expression for all
+ * input outputs mapping. Returns undefined if no mapping exists for the given origin.
+ *
+ * @param {ProcessVariable} variable
+ * @param {djs.model.Base} origin
+ * @returns { expression: String}
+ */
+function getIoExpression(variable, origin) {
   const ioMapping = getExtensionElementsList(origin, 'zeebe:IoMapping')[0];
 
   if (!ioMapping) {
@@ -182,13 +204,28 @@ function getExpressionDetails(variable, origin) {
     return;
   }
 
-  const expression = mapping.source.substring(1);
+  return mapping.source.substring(1);
 
-  const result = getResultContext(expression);
+}
 
-  const unresolved = findUnresolvedVariables(result) ;
+/**
+ * Given a Variable and a specific origin, return the mapping expression for script
+ * task result variable. Returns undefined if no mapping exists for the given origin.
+ *
+ * @param {ProcessVariable} variable
+ * @param {djs.model.Base} origin
+ * @returns { expression: String}
+ */
+function getScriptExpression(variable, origin) {
+  const script = getExtensionElementsList(origin, 'zeebe:Script')[0];
 
-  return { expression, unresolved };
+  if (!script) {
+    return;
+  }
+
+  if (script.resultVariable === variable.name) {
+    return script.expression.substring(1);
+  }
 }
 
 /**

--- a/test/fixtures/zeebe/mappings/script-task.bpmn
+++ b/test/fixtures/zeebe/mappings/script-task.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qieuld" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:scriptTask id="Activity_0kxqawv" name="Script Task">
+      <bpmn:extensionElements>
+        <zeebe:script expression="={&#10;  foo: 123&#10;}" resultVariable="scriptResult" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1g8b868_di" bpmnElement="Activity_0kxqawv">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/zeebe/Mappings.spec.js
+++ b/test/spec/zeebe/Mappings.spec.js
@@ -12,6 +12,7 @@ import chainedMappingsXML from 'test/fixtures/zeebe/mappings/chained-mappings.bp
 import primitivesXML from 'test/fixtures/zeebe/mappings/primitives.bpmn';
 import mergingXML from 'test/fixtures/zeebe/mappings/merging.bpmn';
 import scopeXML from 'test/fixtures/zeebe/mappings/scope.bpmn';
+import scriptTaskXML from 'test/fixtures/zeebe/mappings/script-task.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
 
@@ -310,6 +311,35 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
           name: 'invalidMapping',
           type: '',
           info: ''
+        }
+      ]);
+    }));
+
+  });
+
+
+  describe('Script Task', function() {
+
+    beforeEach(bootstrap(scriptTaskXML));
+
+
+    it('should add type annotation for script tasks', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root.businessObject);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'scriptResult',
+          type: 'Context',
+          info: '',
+          entries: [
+            { name: 'foo', type: 'Number', info: '123', entries: [] },
+          ]
         }
       ]);
     }));


### PR DESCRIPTION
Related to camunda-modeler: [#4614](https://github.com/camunda/camunda-modeler/issues/4614)

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

The context of the script task result variable is now available, providing users with property suggestions for the object.![Dec-03-2024 16-42-07](https://github.com/user-attachments/assets/c67b554a-74e9-462a-bffc-1fb751e6bdf5)



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
