### PR TITLE
fix: do not try to find unresolved variables of a broken expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@bpmn-io/variable-resolver](https://github.com/bpmn-io/v
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.3.5
+
+* `FIX`: do not try to find unresolved variables of a broken expression ([#50](https://github.com/bpmn-io/variable-resolver/issues/50))
+
 ## 1.3.4
 
 * `FIX`: preserve variables with same name but different scopes ([#56](https://github.com/bpmn-io/variable-resolver/pull/56))

--- a/lib/zeebe/util/feelUtility.js
+++ b/lib/zeebe/util/feelUtility.js
@@ -148,6 +148,8 @@ export function getResultContext(expression, variables = {}) {
   try {
     contextualParser.parse(expression);
   } catch (error) {
+
+    // bail out in case of an error
     return latestVariables;
   }
 

--- a/lib/zeebe/util/feelUtility.js
+++ b/lib/zeebe/util/feelUtility.js
@@ -141,10 +141,15 @@ export function getResultContext(expression, variables = {}) {
   });
 
   const contextualParser = parser.configure({
-    contextTracker: customContextTracker
+    contextTracker: customContextTracker,
+    strict: true
   });
 
-  contextualParser.parse(expression);
+  try {
+    contextualParser.parse(expression);
+  } catch (error) {
+    return latestVariables;
+  }
 
   return latestVariables;
 }

--- a/test/fixtures/zeebe/long-broken-expression.bpmn
+++ b/test/fixtures/zeebe/long-broken-expression.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_0j5qzil" name="Agent Blueprint (Long Term Memory)" isExecutable="true">
+    <bpmn:serviceTask id="Task_1" name="Handle customer request">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=For **every** in-scope customer request:&#10;&#10;1. **Inspect** the full list of available tools. Typical tools include, but are not limited to:  &#10;   • `Reply with email to customer` – Give an answer to the customer’s email&#10;   • `Query knowledge base` – Query knowledge base about a certain question. Use this when you need additional information about our oferring with regards to the customer enquiry. &#10;   • `Ask a specialist` – You didn&#39;t find an answer to the customer&#39;s question and you need assitance from a human colleague. You will be able to learn from that colleague and save answer in the knowledge base for future interactions.&#10;&#10;3. **Invoke at least one relevant tool**  &#10;   • Call the same tool multiple times with different inputs if needed.  &#10;   • If no loan-specific tool fits, you **must**  &#10;     a. call a generic search / knowledge tool **or**  &#10;     b. escalate via `Ask a specialist`.  &#10;   • Only if the expert confirms that no tool can help may you answer from general knowledge.  &#10;   • Any choice to skip a potentially helpful tool must be justified inside `&#60;reflection&#62;`.  &#10;4. **Communication mandate**:  &#10;   • To gather information from the **customer**, call `Reply with email to customer`.• To seek guidance from an **expert**, call `Ask a specialist`." target="target" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1imcl82</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1imcl82" sourceRef="Task_1" targetRef="Task_2" />
+    <bpmn:serviceTask id="Task_2">
+      <bpmn:incoming>Flow_1imcl82</bpmn:incoming>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0j5qzil">
+      <bpmndi:BPMNShape id="Activity_1clcfsu_di" bpmnElement="Task_1" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="153" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1a52niu_di" bpmnElement="Task_2">
+        <dc:Bounds x="340" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_06wqta8" bpmnElement="Flow_1imcl82">
+        <di:waypoint x="253" y="120" />
+        <di:waypoint x="340" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -13,6 +13,7 @@ import emptyXML from 'test/fixtures/zeebe/empty.bpmn';
 import complexXML from 'test/fixtures/zeebe/complex.bpmn';
 import connectorsXML from 'test/fixtures/zeebe/connectors.bpmn';
 import ioMappingsXML from 'test/fixtures/zeebe/ioMappings.bpmn';
+import longBrokenExpressionXML from 'test/fixtures/zeebe/long-broken-expression.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
 import { getInputOutput } from '../../../lib/base/util/ExtensionElementsUtil';
@@ -1037,6 +1038,37 @@ describe('ZeebeVariableResolver', function() {
 
     });
 
+  });
+
+
+  describe('parsing', function() {
+
+    beforeEach(bootstrapModeler(longBrokenExpressionXML, {
+      container,
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should NOT error on a long broken expression', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+      const bo = getBusinessObject(task);
+      const input = getInputOutput(bo).inputParameters[1];
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(bo, input);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'target' }
+      ]);
+    }));
   });
 
 });


### PR DESCRIPTION
Closes #50

### Proposed Changes

Currently, we force-try to parse a broken expression. This PR takes advantage of strict parsing to bail out in case a syntax error is encountered.

The issue cannot be reproduced in the `npm start` environment, but you can link it to Desktop Modeler. Below is the demo of a diagram opened without errors:


https://github.com/user-attachments/assets/96df24fa-7633-4631-86ce-61592975cc5c



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
