### PR TITLE
Provide variables used in feel expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 [![CI](https://github.com/bpmn-io/variable-resolver/actions/workflows/CI.yml/badge.svg)](https://github.com/bpmn-io/variable-resolver/actions/workflows/CI.yml)
 
-A bpmn-js extension to add and manage additional variable extractors in bpmn diagrams.
+An extension for [bpmn-js](https://github.com/bpmn-io/bpmn-js) that makes the data model of the diagram available to other components.
+
+> [!NOTE]
+> As of version `v3` this library exposes both written and consumed variables, you can filter them via options.
 
 ## Usage
 
@@ -30,18 +33,55 @@ const modeler = new BpmnModeler({
 
 ### Retrieving variables
 
-To retrieve the variables from a diagram, use one of the following methods of the `variableResolver` service:
+Retrieve the variables from a diagram using the `variableResolver` service:
 
 ```javascript
-const elementRegistry = modeler.get('elementRegistry');
 const variableResolver = modeler.get('variableResolver');
+const elementRegistry = modeler.get('elementRegistry');
 
+// retrieve variables relevant to an element
 const task = elementRegistry.get('Task_1');
-const process = elementRegistry.get('Process_1');
 
-await variableResolver.getVariablesForElement(task); // returns variables in the scope of the element
-await variableResolver.getProcessVariables(process); // returns all variables for the process, not filtering by scope
+// default: variables relevant to <task> in its visible scopes
+await variableResolver.getVariablesForElement(task);
+
+// variables read by <task> only
+await variableResolver.getVariablesForElement(task, {
+  read: true,
+  written: false
+});
+
+// all variables written by <task>
+await variableResolver.getVariablesForElement(task, { written: true, read: false });
+
+// local variables only (scope === queried element)
+await variableResolver.getVariablesForElement(task, {
+  local: true,
+  external: false
+});
+
+// non-local variables only (scope !== queried element)
+await variableResolver.getVariablesForElement(task, {
+  local: false,
+  external: true
+});
+
+// retrieve all variables defined in a process
+const processElement = elementRegistry.get('Process_1');
+
+// returns all variables for the process (unfiltered), for local processing
+await variableResolver.getProcessVariables(processElement);
 ```
+
+`getVariablesForElement(element, options)` supports five filter switches:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `read` | `true` | Include variables consumed by the queried element |
+| `written` | `true` | Include variables written/created by the queried element |
+| `local` | `true` | Include variables local to the queried element scope |
+| `external` | `true` | Include variables outside the queried element scope |
+| `outputMappings` | `true` | Count output-mapping reads as reads |
 
 ### Adding a variable extractor
 
@@ -76,11 +116,9 @@ export const MyExtension = {
 
 ### Advanced use-cases
 
-By default, `getVariablesForElement` and `getProcessVariables` will attempt to merge variables with the same name and scope into
-one. Entry structure and types are then mixed.
+By default, `getVariablesForElement` and `getProcessVariables` merge variables with the same name and scope into one - entry structure and types are mixed in the merged representation.
 
-In some cases, you might want access to the raw data, e.g. to run lint rules to detect potential schema mismatches between providers.
-For this, you can use
+In some cases, you might want access to the raw data, e.g. to run lint rules to detect potential schema mismatches between providers. For this, you can use `getRawVariables`:
 
 ```javascript
 const variableResolver = modeler.get('variableResolver');

--- a/lib/base/VariableResolver.js
+++ b/lib/base/VariableResolver.js
@@ -16,8 +16,23 @@ import { getParents } from './util/elementsUtil';
 /**
  * @typedef {AdditionalVariable} ProcessVariable
  * @property {Array<ModdleElement>} origin
- * @property {ModdleElement} scope
+ * @property {ModdleElement} [scope]
  * @property {Array<Object>} provider
+ * @property {Array<string|ModdleElement>} [usedBy] Elements or variable names consuming this variable
+ * @property {Array<string>} [readFrom] Source tags describing where this variable is read from
+ */
+
+/**
+ * @typedef {Object} VariablesFilterOptions
+ * @property {boolean} [read=true] Include consumed variables
+ * @property {boolean} [written=true] Include variables written in the queried element
+ * @property {boolean} [local=true] Include variables in the queried element scope
+ * @property {boolean} [external=true] Include variables outside the queried element scope
+ * @property {boolean} [outputMappings=true] Include reads originating from output mappings
+ */
+
+/**
+ * @typedef {ProcessVariable} AvailableVariable
  */
 
 /**
@@ -159,12 +174,38 @@ export class BaseVariableResolver {
       variables.forEach(variable => {
         const existingVariable = mergedVariables.find(v =>
           v.name === variable.name && v.scope === variable.scope
+          && (v.scope || !v.usedBy) && (variable.scope || !variable.usedBy)
         );
 
         if (existingVariable) {
           merge('origin', existingVariable, variable);
           merge('provider', existingVariable, variable);
           mergeEntries(existingVariable, variable);
+
+          // Preserve usedBy from either side during merge
+          if (variable.usedBy) {
+            if (!existingVariable.usedBy) {
+              existingVariable.usedBy = [ ...variable.usedBy ];
+            } else {
+              variable.usedBy.forEach(target => {
+                if (!existingVariable.usedBy.includes(target)) {
+                  existingVariable.usedBy.push(target);
+                }
+              });
+            }
+          }
+
+          if (variable.readFrom) {
+            if (!existingVariable.readFrom) {
+              existingVariable.readFrom = [ ...variable.readFrom ];
+            } else {
+              variable.readFrom.forEach(source => {
+                if (!existingVariable.readFrom.includes(source)) {
+                  existingVariable.readFrom.push(source);
+                }
+              });
+            }
+          }
         } else {
           mergedVariables.push(variable);
         }
@@ -249,38 +290,56 @@ export class BaseVariableResolver {
   /**
    * Returns all variables in the scope of the given element.
    *
+   * All filter switches default to `true`
+    *
+    * Use `{ read: true, written: false }` to retrieve read-only variables.
+   *
    * @async
    * @param {ModdleElement} element
-   * @returns {Array<ProcessVariable>} variables
+   * @param {VariablesFilterOptions} [options]
+   * @returns {Promise<Array<AvailableVariable>>} variables
    */
-  async getVariablesForElement(element) {
+  async getVariablesForElement(element, options = {}) {
     const bo = getBusinessObject(element);
+    const filterOptions = normalizeFilterOptions(options);
 
     const root = getRootElement(bo);
     const allVariables = await this.getProcessVariables(root);
 
     // (1) get variables for given scope
     var scopeVariables = allVariables.filter(function(variable) {
-      return variable.scope.id === bo.id;
+      return variable.scope && variable.scope.id === bo.id;
     });
 
     // (2) get variables for parent scopes
     var parents = getParents(bo);
 
     var parentsScopeVariables = allVariables.filter(function(variable) {
-      return parents.find(function(parent) {
+      return variable.scope && parents.find(function(parent) {
         return parent.id === variable.scope.id;
       });
     });
 
-    const reversedVariables = [ ...scopeVariables, ...parentsScopeVariables ].reverse();
+    // (3) include descendant-scoped variables that are used outside their
+    // own scope but still within the current scope (cross-scope leak)
+    const leakedVariables = allVariables.filter(variable => {
+      return variable.scope
+        && variable.scope.id !== bo.id
+        && isElementInScope(variable.scope, bo)
+        && isUsedInScope(variable, bo)
+        && isUsedOutsideOwnScope(variable);
+    });
+
+    const reversedVariables = [ ...leakedVariables, ...scopeVariables, ...parentsScopeVariables ].reverse();
 
     const seenNames = new Set();
 
-    return reversedVariables.filter(variable => {
+    const deduplicatedVariables = reversedVariables.filter(variable => {
+
+      const provider = variable.provider || [];
 
       // if external variable, keep
-      if (variable.provider.find(extractor => extractor !== this._baseExtractor)) {
+      if (provider.find(extractor => extractor !== this._baseExtractor)) {
         return true;
       }
 
@@ -293,12 +352,58 @@ export class BaseVariableResolver {
 
       return false;
     });
+
+    const projectedScopedVariables = deduplicatedVariables.map(variable => {
+      if (!variable.usedBy || !Array.isArray(variable.usedBy)) {
+        return variable;
+      }
+
+      const usedBy = filterUsedByForElement(variable, bo);
+
+      if (isSameUsageList(variable.usedBy, usedBy)) {
+        return variable;
+      }
+
+      return {
+        ...variable,
+        usedBy: usedBy.length ? usedBy : undefined
+      };
+    });
+
+    const consumedVariables = allVariables.filter(variable => {
+      return !variable.scope
+        && Array.isArray(variable.usedBy)
+        && variable.usedBy.some(usage => usage && usage.id === bo.id);
+    });
+
+    let candidates = projectedScopedVariables;
+
+    if (filterOptions.read && !filterOptions.written) {
+      candidates = [ ...projectedScopedVariables, ...consumedVariables ];
+    } else if (filterOptions.read && filterOptions.written && !projectedScopedVariables.length) {
+
+      // Preserve current default behavior: only fall back to consumed variables
+      // when no scoped/ancestor variables are available.
+      candidates = consumedVariables;
+    }
+
+    return candidates.filter(variable => {
+      const isLocal = !!(variable.scope && variable.scope.id === bo.id);
+      const hasReadUsage = !!(variable.usedBy && variable.usedBy.length);
+      const readSources = Array.isArray(variable.readFrom) ? variable.readFrom : [];
+      const hasOutputMappingRead = hasReadSource(readSources, 'output-mapping');
+      const hasNonOutputRead = hasReadUsage && (!readSources.length || readSources.some(source => source !== 'output-mapping'));
+      const isRead = hasNonOutputRead || (filterOptions.outputMappings && hasOutputMappingRead);
+      const isWritten = !!(variable.origin && variable.origin.some(origin => origin && origin.id === bo.id));
+
+      return matchesTypeFilter(isRead, isWritten, filterOptions)
+        && matchesScopeFilter(isLocal, filterOptions);
+    });
   }
 
   _getScope(element, containerElement, variableName, checkYourself) {
     throw new Error('not implemented VariableResolver#_getScope');
   }
-
 }
 
 BaseVariableResolver.$inject = [ 'eventBus', 'bpmnjs' ];
@@ -396,4 +501,146 @@ function cloneVariable(variable) {
   }
 
   return newVariable;
+}
+
+function isUsedInScope(variable, scopeElement) {
+  if (!variable.usedBy || !Array.isArray(variable.usedBy)) {
+    return false;
+  }
+
+  return variable.usedBy.some(usedBy => isElementInScope(usedBy, scopeElement));
+}
+
+function isElementInScope(element, scopeElement) {
+  if (!element || !element.id || !scopeElement || !scopeElement.id) {
+    return false;
+  }
+
+  if (element.id === scopeElement.id) {
+    return true;
+  }
+
+  return getParents(element).some(parent => parent.id === scopeElement.id);
+}
+
+function isUsedOutsideOwnScope(variable) {
+  if (!variable.scope || !Array.isArray(variable.usedBy)) {
+    return false;
+  }
+
+  return variable.usedBy.some(usedBy => {
+    return usedBy && usedBy.id && !isElementInScope(usedBy, variable.scope);
+  });
+}
+
+function filterUsedByForElement(variable, element) {
+  const names = variable.usedBy.filter(usage => typeof usage === 'string');
+  const elements = variable.usedBy.filter(usage => usage && usage.id);
+
+  if (!variable.scope) {
+    return elements;
+  }
+
+  // Querying the variable's own scope: show local consumers.
+  if (element.id === variable.scope.id) {
+    const localConsumers = elements.filter(usage => isElementInScope(usage, variable.scope));
+
+    if (localConsumers.length) {
+      return localConsumers;
+    }
+
+    // For local mapping dependencies represented as names, expose the
+    // querying element as the consumer.
+    return names.length ? [ element ] : [];
+  }
+
+  // Querying an ancestor scope: show consumers outside the variable's own scope.
+  if (isElementInScope(variable.scope, element)) {
+    return elements.filter(usage =>
+      isElementInScope(usage, element)
+      && !isElementInScope(usage, variable.scope)
+    );
+  }
+
+  // Querying a child scope: show consumers in that child scope only.
+  if (isElementInScope(element, variable.scope)) {
+    return elements.filter(usage => isElementInScope(usage, element));
+  }
+
+  return [];
+}
+
+function normalizeFilterOptions(options) {
+  options = options || {};
+
+  return {
+    read: options.read !== false,
+    written: options.written !== false,
+    local: options.local !== false,
+    external: options.external !== false,
+    outputMappings: options.outputMappings !== false
+  };
+}
+
+function matchesTypeFilter(isRead, isWritten, options) {
+  if (options.read && options.written) {
+    return true;
+  }
+
+  if (options.read) {
+    return isRead;
+  }
+
+  if (options.written) {
+    return isWritten;
+  }
+
+  return false;
+}
+
+function matchesScopeFilter(isLocal, options) {
+  if (options.local && options.external) {
+    return true;
+  }
+
+  if (options.local) {
+    return isLocal;
+  }
+
+  if (options.external) {
+    return !isLocal;
+  }
+
+  return false;
+}
+
+function isSameUsageList(usagesA, usagesB) {
+  if (!Array.isArray(usagesA) || !Array.isArray(usagesB)) {
+    return false;
+  }
+
+  if (usagesA.length !== usagesB.length) {
+    return false;
+  }
+
+  const keysA = usagesA.map(getUsageKey).sort();
+  const keysB = usagesB.map(getUsageKey).sort();
+
+  return keysA.every((key, index) => key === keysB[index]);
+}
+
+function getUsageKey(usage) {
+  if (typeof usage === 'string') {
+    return `name:${usage}`;
+  }
+
+  if (usage && usage.id) {
+    return `id:${usage.id}`;
+  }
+
+  return String(usage);
+}
+
+function hasReadSource(readFrom, sourceName) {
+  return Array.isArray(readFrom) && readFrom.includes(sourceName);
 }

--- a/lib/zeebe/VariableResolver.js
+++ b/lib/zeebe/VariableResolver.js
@@ -2,7 +2,8 @@ import { getProcessVariables, getScope } from '@bpmn-io/extract-process-variable
 import { BaseVariableResolver } from '../base/VariableResolver';
 import {
   parseVariables,
-  getElementNamesToRemove
+  getElementNamesToRemove,
+  extractConsumedVariablesFromElements
 } from './util/feelUtility';
 import {
   getBusinessObject,
@@ -25,12 +26,37 @@ export default class ZeebeVariableResolver extends BaseVariableResolver {
     this._baseExtractor = getProcessVariables;
     this._getScope = getScope;
 
-    eventBus.on('variableResolver.parseVariables', HIGHER_PRIORITY, this._resolveVariables);
+    eventBus.on('variableResolver.parseVariables', HIGHER_PRIORITY, this._resolveVariables.bind(this));
     eventBus.on('variableResolver.parseVariables', HIGH_PRIORITY, this._expandVariables);
   }
 
-  async getVariablesForElement(element, moddleElement) {
-    const variables = await super.getVariablesForElement(element);
+  /**
+   * Returns variables for an element.
+   *
+   * Supported signatures:
+   * - `getVariablesForElement(element, options)`
+   * - `getVariablesForElement(element, moddleElement, options)`
+   *
+   * The second signature can be used to remove pre-defined mapping variables
+   * from the result based on the given moddle element.
+   *
+   * @param {ModdleElement} element
+    * @param {ModdleElement|Object} [optionsOrModdleElement] A moddle element or filter options
+    * @param {Object} [options] Filter options when a moddle element is provided
+    * @param {boolean} [options.read]
+    * @param {boolean} [options.written]
+    * @param {boolean} [options.local]
+    * @param {boolean} [options.external]
+    * @param {boolean} [options.outputMappings]
+   * @returns {Promise<Array<ProcessVariable>>}
+   */
+  async getVariablesForElement(element, optionsOrModdleElement, options) {
+    const {
+      moddleElement,
+      filterOptions
+    } = normalizeGetVariablesForElementArguments(optionsOrModdleElement, options);
+
+    const variables = await super.getVariablesForElement(element, filterOptions);
 
     const bo = getBusinessObject(element);
 
@@ -49,7 +75,7 @@ export default class ZeebeVariableResolver extends BaseVariableResolver {
     return variables.filter(v => {
 
       // Keep all variables that are also defined in other elements
-      if (v.origin.length > 1 || v.origin[0] !== bo) {
+      if (!Array.isArray(v.origin) || v.origin.length > 1 || v.origin[0] !== bo) {
         return true;
       }
 
@@ -95,18 +121,83 @@ export default class ZeebeVariableResolver extends BaseVariableResolver {
    */
   _resolveVariables(e, context) {
     const rawVariables = context.variables;
+    const definitions = this._bpmnjs.getDefinitions();
 
     const mappedVariables = {};
 
     for (const key in rawVariables) {
       const variables = rawVariables[key];
-      const newVariables = parseVariables(variables);
+      const { resolvedVariables, consumedVariables } = parseVariables(variables);
+      const rootElement = getRootElementById(definitions, key);
+      const elementConsumedVariables = rootElement
+        ? extractConsumedVariablesFromElements(getFlowElements(rootElement))
+        : [];
 
-      mappedVariables[key] = [ ...variables, ...newVariables ];
+      mappedVariables[key] = [
+        ...variables,
+        ...resolvedVariables,
+        ...consumedVariables,
+        ...elementConsumedVariables
+      ];
     }
 
     context.variables = mappedVariables;
   }
+}
+
+function normalizeGetVariablesForElementArguments(optionsOrModdleElement, options) {
+  const looksLikeOptions = isFilterOptions(optionsOrModdleElement);
+
+  if (looksLikeOptions) {
+    return {
+      moddleElement: null,
+      filterOptions: optionsOrModdleElement
+    };
+  }
+
+  return {
+    moddleElement: optionsOrModdleElement || null,
+    filterOptions: isFilterOptions(options) ? options : undefined
+  };
+}
+
+function isFilterOptions(value) {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return [ 'read', 'written', 'local', 'external', 'outputMappings' ].some(key => key in value);
+}
+
+function getRootElementById(definitions, id) {
+  if (!definitions || !Array.isArray(definitions.rootElements)) {
+    return null;
+  }
+
+  return definitions.rootElements.find(root => root && root.id === id) || null;
+}
+
+function getFlowElements(rootElement) {
+  const flowElements = [];
+  const queue = [ rootElement ];
+
+  while (queue.length) {
+    const element = queue.shift();
+
+    if (!element || !Array.isArray(element.flowElements)) {
+      continue;
+    }
+
+    for (const flowElement of element.flowElements) {
+      flowElements.push(flowElement);
+
+      if (Array.isArray(flowElement.flowElements)) {
+        queue.push(flowElement);
+      }
+    }
+  }
+
+  return flowElements;
 }
 
 /**
@@ -146,6 +237,7 @@ function expandHierarchicalNames(variables) {
         scope,
         provider,
         origin,
+        usedBy: lastVariable.usedBy ? [ ...lastVariable.usedBy ] : undefined,
         entries: [
           lastVariable
         ]

--- a/lib/zeebe/util/feelUtility.js
+++ b/lib/zeebe/util/feelUtility.js
@@ -4,37 +4,232 @@ import {
 } from '@lezer/lr';
 
 import { has, isNil } from 'min-dash';
+import { FeelAnalyzer } from '@bpmn-io/feel-analyzer';
 
 import { EntriesContext } from './VariableContext';
 import { getExtensionElementsList } from '../../base/util/ExtensionElementsUtil';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 import { getParents } from '../../base/util/elementsUtil';
 import { mergeList } from '../../base/util/listUtil';
+import { mergeEntries } from '../../base/VariableResolver';
+import { camundaBuiltins, camundaReservedNameBuiltins } from '@camunda/feel-builtins';
 
+const feelAnalyzer = new FeelAnalyzer({
+  dialect: 'expression',
+  parserDialect: 'camunda',
+  builtins: camundaBuiltins,
+  reservedNameBuiltins: camundaReservedNameBuiltins
+});
+
+/**
+ * Parse FEEL-based variable expressions and return resolved + consumed variables.
+ *
+ * This includes script expressions and IO mappings, and is designed to handle
+ * FEEL-enabled variable definitions exposed by the collected variable origins.
+ * Resolution uses the highest-priority expression for each variable/origin pair.
+ * Consumption analysis inspects all relevant non-output expressions.
+ *
+ * @param {Array<ProcessVariable>} variables
+ * @returns {{ resolvedVariables: Array<ProcessVariable>, consumedVariables: Array<ProcessVariable> }}
+ */
 export function parseVariables(variables) {
-
   const variablesToResolve = [];
+  const analysisResults = [];
 
   // Step 1 - Parse all variables and populate all that don't have references
   // to other variables
   variables.forEach(variable => {
     variable.origin.forEach(origin => {
-      const expressionDetails = getExpressionDetails(variable, origin);
+      const expressionCandidates = findExpressions(variable, origin);
 
-      if (!expressionDetails) {
+      if (expressionCandidates.length === 0) {
         return;
       }
 
-      const { expression, unresolved } = expressionDetails;
+      const expression = selectPrimaryExpression(expressionCandidates);
+
+      if (isNil(expression)) {
+        return;
+      }
+
+      const expressionDetails = getExpressionDetails(expression);
+
+      const {
+        unresolved
+      } = expressionDetails;
 
       variablesToResolve.push({ variable, expression, unresolved });
+
+      const requirementAnalyses = collectRequirementAnalyses(expressionCandidates, expression, expressionDetails);
+
+      for (const { expressionType, inputs } of requirementAnalyses) {
+        analysisResults.push({
+          origin,
+          scope: origin,
+          targetName: variable.name,
+          inputs,
+          expressionType
+        });
+      }
     });
   });
 
   // Step 2 - Order all Variables and resolve them
-  return resolveReferences(variablesToResolve, variables);
+  const resolvedVariables = resolveReferences(variablesToResolve, variables);
+
+  // Step 3 - Build consumed variables from collected analyses
+  const { consumed: consumedVariables, localUsages } = buildConsumedVariables(analysisResults);
+
+  // Step 4 - Annotate locally-provided variables with usedBy information
+  for (const { variableName, targetName, origin, expressionType } of localUsages) {
+    const variable = findNearestScopedVariable(variables, variableName, origin);
+
+    if (!variable) {
+      continue;
+    }
+
+    // Keep existing behavior for same-origin mappings (`usedBy: [ 'targetVar' ]`)
+    // and use the consuming element for ancestor-scoped variables.
+    const usage = variable.scope === origin ? targetName : origin;
+
+    if (!variable.usedBy) {
+      variable.usedBy = [];
+    }
+
+    if (!hasUsage(variable.usedBy, usage)) {
+      variable.usedBy.push(usage);
+    }
+
+    if (!variable.readFrom) {
+      variable.readFrom = [];
+    }
+
+    if (!variable.readFrom.includes(expressionType)) {
+      variable.readFrom.push(expressionType);
+    }
+  }
+
+  // Step 5 - Bridge consumed usages back to uniquely scoped declarations
+  annotateConsumedUsagesToScopedVariables(variables, consumedVariables);
+
+  return { resolvedVariables, consumedVariables };
 }
 
+function annotateConsumedUsagesToScopedVariables(variables, consumedVariables) {
+  for (const consumedVariable of consumedVariables) {
+    const candidateNames = getConsumedVariableCandidateNames(consumedVariable);
+
+    for (const candidateName of candidateNames) {
+      annotateConsumedUsagesToScopedVariableByName(
+        variables,
+        candidateName,
+        consumedVariable.usedBy || [],
+        consumedVariable.readFrom || []
+      );
+    }
+  }
+}
+
+function annotateConsumedUsagesToScopedVariableByName(variables, variableName, usages, readFrom) {
+  const scopedCandidates = variables.filter(v => v.name === variableName && v.scope);
+
+  if (scopedCandidates.length !== 1) {
+    return;
+  }
+
+  const scopedVariable = scopedCandidates[0];
+
+  if (!scopedVariable.usedBy) {
+    scopedVariable.usedBy = [];
+  }
+
+  if (!scopedVariable.readFrom) {
+    scopedVariable.readFrom = [];
+  }
+
+  for (const usage of usages) {
+    if (!usage || !usage.id) {
+      continue;
+    }
+
+    if (!hasUsage(scopedVariable.usedBy, usage)) {
+      scopedVariable.usedBy.push(usage);
+    }
+  }
+
+  readFrom.forEach(source => {
+    if (!scopedVariable.readFrom.includes(source)) {
+      scopedVariable.readFrom.push(source);
+    }
+  });
+}
+
+function getConsumedVariableCandidateNames(consumedVariable) {
+  const names = [ consumedVariable.name ];
+
+  if (!consumedVariable.entries || !consumedVariable.entries.length) {
+    return names;
+  }
+
+  return [
+    ...names,
+    ...getNestedConsumedVariableNames(consumedVariable.name, consumedVariable.entries)
+  ];
+}
+
+function getNestedConsumedVariableNames(prefix, entries) {
+  const names = [];
+
+  for (const entry of entries || []) {
+    const name = `${prefix}.${entry.name}`;
+    names.push(name);
+
+    if (entry.entries && entry.entries.length) {
+      names.push(...getNestedConsumedVariableNames(name, entry.entries));
+    }
+  }
+
+  return names;
+}
+
+function findNearestScopedVariable(variables, variableName, origin) {
+  const scopes = [ origin, ...getParents(origin) ];
+
+  for (const scope of scopes) {
+    const variable = variables.find(v => v.name === variableName && v.scope === scope);
+
+    if (variable) {
+      return variable;
+    }
+  }
+
+  return null;
+}
+
+function hasUsage(usages, usage) {
+  return usages.some(existing => {
+    if (existing === usage) {
+      return true;
+    }
+
+    if (typeof existing === 'string' && typeof usage === 'string') {
+      return existing === usage;
+    }
+
+    return existing && usage && existing.id && usage.id && existing.id === usage.id;
+  });
+}
+
+/**
+ * Resolve variable expressions against each other in dependency order.
+ *
+ * Variables with expression mappings are evaluated in a best-effort topological
+ * order. Variables without mappings are provided as initial context.
+ *
+ * @param {Array<{ variable: ProcessVariable, expression: string, unresolved: Array<string> }>} variablesToResolve
+ * @param {Array<ProcessVariable>} allVariables
+ * @returns {Array<ProcessVariable>}
+ */
 function resolveReferences(variablesToResolve, allVariables) {
   const sortedVariables = [];
 
@@ -73,7 +268,7 @@ function resolveReferences(variablesToResolve, allVariables) {
 
   const rootContext = {
     name: 'OuterContext',
-    entries: toOptimizedFormat(variablesWithoutMappings)
+    entries: toOptimizedFormat(variablesWithoutMappings.filter(v => v.scope))
   };
 
   const newVariables = [];
@@ -218,56 +413,139 @@ export function getResultContext(expression, variables = {}) {
 }
 
 /**
- * Given a Variable and a specific origin, return the mapping expression and all
- * unresolved variables used in that expression. Returns undefined if no mapping
- * exists for the given origin.
+ * Find all matching expression sources for a variable on a given origin element.
+ *
+ * Returns candidates ordered by resolution priority (first = highest).
+ * Local variables: script > input-mapping (script result overwrites at runtime).
+ * Global variables: output-mapping > script.
  *
  * @param {ProcessVariable} variable
  * @param {djs.model.Base} origin
- * @returns {{ expression: string, unresolved: Array<string> }}}
+ * @returns {Array<{ type: string, value: string }>}
  */
-function getExpressionDetails(variable, origin) {
+function findExpressions(variable, origin) {
+  const isLocal = variable.scope === origin;
 
-  // if variable scope is !== origin (global), prioritize IoExpression over ScriptExpression
-  // if variable scope is === origin (local), prioritize ScriptExpression over IoExpression
-  const expression = variable.scope !== origin
-    ? getIoExpression(variable, origin) ?? getScriptExpression(variable, origin)
-    : getScriptExpression(variable, origin) ?? getIoExpression(variable, origin);
+  const candidates = isLocal
+    ? [
+      { type: 'script', value: getScriptExpression(variable, origin) },
+      { type: 'input-mapping', value: getIoInputExpression(variable, origin) },
+    ]
+    : [
+      { type: 'output-mapping', value: getIoOutputExpression(variable, origin) },
+      { type: 'script', value: getScriptExpression(variable, origin) },
+    ];
 
-  if (isNil(expression)) {
-    return;
-  }
-
-  const result = getResultContext(expression);
-
-  const unresolved = findUnresolvedVariables(result);
-
-  return { expression, unresolved };
+  return candidates.filter(c => !isNil(c.value));
 }
 
 /**
- * Given a Variable and a specific origin, return the expression.
+ * Pick the highest-priority expression from expression candidates.
  *
- * Returns `undefined` if no mapping exists for the given origin.
+ * @param {Array<{ type: string, value: string }>} expressionCandidates
+ * @returns {string|undefined}
+ */
+function selectPrimaryExpression(expressionCandidates) {
+  const [ primary ] = expressionCandidates;
+
+  return primary && primary.value;
+}
+
+/**
+ * Analyze candidate expressions for consumed variables.
+ *
+ * Includes output mappings so callers can decide whether to show or filter
+ * output-mapping reads.
+ *
+ * @param {Array<{ type: string, value: string }>} expressionCandidates
+ * @param {string} primaryExpression
+ * @param {{ unresolved: Array<string>, inputs: Array }} primaryExpressionDetails
+ * @returns {Array<{ expressionType: string, inputs: Array }>}
+ */
+function collectRequirementAnalyses(expressionCandidates, primaryExpression, primaryExpressionDetails) {
+  const requirementAnalyses = [];
+
+  for (const { type, value } of expressionCandidates) {
+    const analysis = value === primaryExpression
+      ? primaryExpressionDetails
+      : getExpressionDetails(value);
+
+    if (analysis.inputs.length > 0) {
+      requirementAnalyses.push({
+        expressionType: type,
+        inputs: analysis.inputs
+      });
+    }
+  }
+
+  return requirementAnalyses;
+}
+
+/**
+ * Given a FEEL expression, return unresolved variables and consumed input variables.
+ *
+ * @param {string} expression
+ * @returns {{ unresolved: Array<string>, inputs: Array }}
+ */
+function getExpressionDetails(expression) {
+
+  const result = getResultContext(expression);
+  const unresolved = findUnresolvedVariables(result);
+
+  // Static values (no leading '=') are string literals, not FEEL expressions.
+  // They don't reference any variables and must not be analyzed for inputs.
+  if (!expression.startsWith('=')) {
+    return { unresolved, inputs: [] };
+  }
+
+  const analysisResult = feelAnalyzer.analyzeExpression(expression);
+  const inputs = analysisResult.valid !== false && analysisResult.inputs
+    ? analysisResult.inputs
+    : [];
+
+  return { unresolved, inputs };
+}
+
+/**
+ * Given a variable and origin, return input mapping expression targeting the variable.
  *
  * @param {ProcessVariable} variable
  * @param {djs.model.Base} origin
- *
  * @returns {string|undefined}
  */
-function getIoExpression(variable, origin) {
+function getIoInputExpression(variable, origin) {
+  return getIoExpressionByType(variable, origin, 'input');
+}
+
+/**
+ * Given a variable and origin, return output mapping expression targeting the variable.
+ *
+ * @param {ProcessVariable} variable
+ * @param {djs.model.Base} origin
+ * @returns {string|undefined}
+ */
+function getIoOutputExpression(variable, origin) {
+  return getIoExpressionByType(variable, origin, 'output');
+}
+
+/**
+ * Given a variable and origin, return mapping expression by mapping type.
+ *
+ * @param {ProcessVariable} variable
+ * @param {djs.model.Base} origin
+ * @param {'input'|'output'} mappingType
+ * @returns {string|undefined}
+ */
+function getIoExpressionByType(variable, origin, mappingType) {
   const ioMapping = getExtensionElementsList(origin, 'zeebe:IoMapping')[0];
 
   if (!ioMapping) {
     return;
   }
 
-  let mappings;
-  if (origin === variable.scope) {
-    mappings = ioMapping.inputParameters;
-  } else {
-    mappings = ioMapping.outputParameters;
-  }
+  const mappings = mappingType === 'input'
+    ? ioMapping.inputParameters
+    : ioMapping.outputParameters;
 
   if (!mappings) {
     return;
@@ -287,7 +565,7 @@ function getIoExpression(variable, origin) {
  *
  * @param {ProcessVariable} variable
  * @param {djs.model.Base} origin
- * @returns {string}
+ * @returns {string|undefined}
  */
 function getScriptExpression(variable, origin) {
   const script = getExtensionElementsList(origin, 'zeebe:Script')[0];
@@ -459,7 +737,7 @@ function filterForScope(context, variable) {
   for (const key in context.entries) {
     const entry = context.entries[key];
 
-    if (validScopes.find(scope => scope.id === entry.scope.id)) {
+    if (entry.scope && validScopes.find(scope => scope.id === entry.scope.id)) {
       scopedResults.entries[key] = entry;
     }
   }
@@ -510,3 +788,201 @@ export function getElementNamesToRemove(moddleElement, inputOutput) {
 
   return namesToFilter;
 }
+
+/**
+ * Extract consumed variables from FEEL expressions that are not represented by
+ * variable mappings, e.g. sequence flow conditions and receive-task
+ * subscription keys.
+ *
+ * @param {Array<ModdleElement>} elements
+ * @returns {Array<ProcessVariable>}
+ */
+export function extractConsumedVariablesFromElements(elements = []) {
+  const consumedVariables = new Map();
+
+  const elementExpressions = getElementExpressions(elements);
+
+  for (const { element, expression } of elementExpressions) {
+    const { inputs } = getExpressionDetails(expression);
+
+    for (const inputVar of inputs) {
+      const existingVariable = consumedVariables.get(inputVar.name);
+
+      if (!existingVariable) {
+        consumedVariables.set(inputVar.name, {
+          name: inputVar.name,
+          origin: undefined,
+          scope: undefined,
+          entries: inputVar.entries || [],
+          usedBy: [ element ]
+        });
+
+        continue;
+      }
+
+      if (inputVar.entries && inputVar.entries.length) {
+        mergeEntries(existingVariable, { entries: inputVar.entries });
+      }
+
+      if (!hasUsage(existingVariable.usedBy, element)) {
+        existingVariable.usedBy.push(element);
+      }
+    }
+  }
+
+  return Array.from(consumedVariables.values());
+}
+
+function getElementExpressions(elements) {
+  const expressions = [];
+
+  for (const element of elements) {
+    if (is(element, 'bpmn:SequenceFlow')) {
+      const conditionExpression = element.conditionExpression && element.conditionExpression.body;
+
+      if (typeof conditionExpression === 'string' && conditionExpression.trim()) {
+        expressions.push({
+          element,
+          expression: conditionExpression
+        });
+      }
+    }
+
+    if (is(element, 'bpmn:ReceiveTask')) {
+      const message = element.messageRef;
+
+      if (!message) {
+        continue;
+      }
+
+      const subscription = getExtensionElementsList(message, 'zeebe:Subscription')[0];
+
+      if (!subscription || !subscription.correlationKey) {
+        continue;
+      }
+
+      expressions.push({
+        element,
+        expression: subscription.correlationKey
+      });
+    }
+  }
+
+  return expressions;
+}
+
+/**
+ * Build consumed variables from pre-collected analysis results.
+ *
+ * @param {Array<{ origin: object, targetName: string, inputs: Array, expressionType: string }>} analysisResults
+ * @returns {Array<ProcessVariable>} consumed variables
+ */
+function buildConsumedVariables(analysisResults) {
+  const consumedVariables = {};
+  const localUsages = [];
+  const inputMappingTargetsCache = {};
+
+  for (const { origin, targetName, inputs, expressionType } of analysisResults) {
+    const availableLocalTargets = getAvailableLocalTargets(
+      origin,
+      expressionType,
+      targetName,
+      inputMappingTargetsCache
+    );
+
+    for (const inputVar of inputs) {
+
+      // Output mappings should annotate local read usage but not create global
+      // consumed variables.
+      if (expressionType === 'output-mapping') {
+        localUsages.push({
+          variableName: inputVar.name,
+          origin,
+          targetName,
+          expressionType
+        });
+        continue;
+      }
+
+      // Track locally-provided variables that are used by output expressions
+      if (availableLocalTargets.has(inputVar.name)) {
+        localUsages.push({
+          variableName: inputVar.name,
+          origin,
+          targetName,
+          expressionType
+        });
+        continue;
+      }
+
+      const key = `${inputVar.name}__${origin.id}`;
+
+      if (!consumedVariables[key]) {
+        consumedVariables[key] = {
+          name: inputVar.name,
+          origin: undefined,
+          entries: inputVar.entries || [],
+          usedBy: [ origin ],
+          readFrom: [ expressionType ]
+        };
+      } else {
+        if (!consumedVariables[key].usedBy.includes(targetName)) {
+          consumedVariables[key].usedBy.push(targetName);
+        }
+
+        // Merge entries from the new input into the existing requirement
+        // e.g. `a.b` and `a.c` should result in `a: {b, c}`
+        if (inputVar.entries && inputVar.entries.length) {
+          mergeEntries(consumedVariables[key], { entries: inputVar.entries });
+        }
+
+        if (!consumedVariables[key].readFrom.includes(expressionType)) {
+          consumedVariables[key].readFrom.push(expressionType);
+        }
+      }
+    }
+  }
+
+  return { consumed: Object.values(consumedVariables), localUsages };
+}
+
+/**
+ * Get ordered input mapping target names for an element.
+ *
+ * @param {djs.model.Base} origin
+ * @returns {Array<string>}
+ */
+function getInputMappingTargetNames(origin) {
+  const ioMapping = getExtensionElementsList(origin, 'zeebe:IoMapping')[0];
+  if (!ioMapping || !ioMapping.inputParameters) return [];
+  return ioMapping.inputParameters.map(p => p.target);
+}
+
+function getAvailableLocalTargets(origin, expressionType, targetName, inputMappingTargetsCache) {
+  const availableTargets = new Set();
+  const scopes = [ origin, ...getParents(origin) ];
+
+  for (const scope of scopes) {
+    if (!inputMappingTargetsCache[scope.id]) {
+      inputMappingTargetsCache[scope.id] = getInputMappingTargetNames(scope);
+    }
+
+    const orderedTargets = inputMappingTargetsCache[scope.id];
+
+    // Input mappings on the current element are order-sensitive; ancestor
+    // mappings are already established and fully available.
+    if (scope === origin && expressionType === 'input-mapping') {
+      const targetIndex = orderedTargets.indexOf(targetName);
+      const availableOwnTargets = targetIndex === -1 ? orderedTargets : orderedTargets.slice(0, targetIndex);
+
+      availableOwnTargets.forEach(target => availableTargets.add(target));
+      continue;
+    }
+
+    orderedTargets.forEach(target => availableTargets.add(target));
+  }
+
+  return availableTargets;
+}
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^2.2.1",
+        "@bpmn-io/feel-analyzer": "^0.1.0",
         "@bpmn-io/lezer-feel": "^2.3.1",
+        "@camunda/feel-builtins": "^1.0.0",
         "@lezer/common": "^1.5.1",
         "min-dash": "^5.0.0"
       },
@@ -421,6 +423,18 @@
         "min-dash": "^5.0.0"
       }
     },
+    "node_modules/@bpmn-io/feel-analyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-analyzer/-/feel-analyzer-0.1.0.tgz",
+      "integrity": "sha512-lQp3EZY6WbBI0y0PwnlXIk+fJO9yZpotFbd2a1UaIrule9i+wk9au99J+Md1RjT38GiqcBzk2mMftRkRb8Iezg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@bpmn-io/feel-editor": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.5.0.tgz",
@@ -546,7 +560,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.0.0.tgz",
       "integrity": "sha512-/0w86UVmNcNqlZB9n/4Ro5wqHt+JuBKwD8kt+O7ASxSqs80D1y4BMfgu+We+O7cA8MWbt9eNKUjwRgGf4f75TQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
@@ -8944,6 +8957,14 @@
         "min-dash": "^5.0.0"
       }
     },
+    "@bpmn-io/feel-analyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-analyzer/-/feel-analyzer-0.1.0.tgz",
+      "integrity": "sha512-lQp3EZY6WbBI0y0PwnlXIk+fJO9yZpotFbd2a1UaIrule9i+wk9au99J+Md1RjT38GiqcBzk2mMftRkRb8Iezg==",
+      "requires": {
+        "@bpmn-io/lezer-feel": "^2.1.0"
+      }
+    },
     "@bpmn-io/feel-editor": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.5.0.tgz",
@@ -9042,8 +9063,7 @@
     "@camunda/feel-builtins": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.0.0.tgz",
-      "integrity": "sha512-/0w86UVmNcNqlZB9n/4Ro5wqHt+JuBKwD8kt+O7ASxSqs80D1y4BMfgu+We+O7cA8MWbt9eNKUjwRgGf4f75TQ==",
-      "dev": true
+      "integrity": "sha512-/0w86UVmNcNqlZB9n/4Ro5wqHt+JuBKwD8kt+O7ASxSqs80D1y4BMfgu+We+O7cA8MWbt9eNKUjwRgGf4f75TQ=="
     },
     "@camunda/zeebe-element-templates-json-schema": {
       "version": "0.36.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "license": "MIT",
   "dependencies": {
     "@bpmn-io/extract-process-variables": "^2.2.1",
+    "@bpmn-io/feel-analyzer": "^0.1.0",
     "@bpmn-io/lezer-feel": "^2.3.1",
+    "@camunda/feel-builtins": "^1.0.0",
     "@lezer/common": "^1.5.1",
     "min-dash": "^5.0.0"
   },

--- a/test/fixtures/zeebe/filtering.bpmn
+++ b/test/fixtures/zeebe/filtering.bpmn
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0modwgr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" name="Process_1" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" name="SubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=globalFoo" target="subFoo" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:scriptTask id="Task_1" name="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=&#34;Task_1 :: result&#34; + taskFoo" resultVariable="localResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=subFoo" target="taskFoo" />
+            <zeebe:output source="=localResult" target="taskResult" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:subProcess>
+    <bpmn:textAnnotation id="TextAnnotation_0htuzu9">
+      <bpmn:text>declare: subFoo = globalFoo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0aa1wd0" associationDirection="None" sourceRef="SubProcess_1" targetRef="TextAnnotation_0htuzu9" />
+    <bpmn:textAnnotation id="TextAnnotation_07tfbe4">
+      <bpmn:text>declare: taskFoo = subFoo
+read: taskFoo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_17fzlji" associationDirection="None" sourceRef="Task_1" targetRef="TextAnnotation_07tfbe4" />
+    <bpmn:textAnnotation id="TextAnnotation_0x7whlg">
+      <bpmn:text>write: localResult (-&gt; depending on taskFoo)</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0yn1gyn" associationDirection="None" sourceRef="Task_1" targetRef="TextAnnotation_0x7whlg" />
+    <bpmn:textAnnotation id="TextAnnotation_0cxitau">
+      <bpmn:text>produce: taskResult = localResult</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_14e87h9" associationDirection="None" sourceRef="Task_1" targetRef="TextAnnotation_0cxitau" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0zpajl6_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="290" y="180" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ie6k5k_di" bpmnElement="Task_1">
+        <dc:Bounds x="360" y="240" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0aa1wd0_di" bpmnElement="Association_0aa1wd0">
+        <di:waypoint x="303" y="180" />
+        <di:waypoint x="250" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_14e87h9_di" bpmnElement="Association_14e87h9">
+        <di:waypoint x="451" y="320" />
+        <di:waypoint x="565" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_17fzlji_di" bpmnElement="Association_17fzlji">
+        <di:waypoint x="375" y="320" />
+        <di:waypoint x="283" y="424" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0yn1gyn_di" bpmnElement="Association_0yn1gyn">
+        <di:waypoint x="404" y="320" />
+        <di:waypoint x="382" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0htuzu9_di" bpmnElement="TextAnnotation_0htuzu9">
+        <dc:Bounds x="190" y="70" width="180" height="29.999998092651367" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0cxitau_di" bpmnElement="TextAnnotation_0cxitau">
+        <dc:Bounds x="530" y="430" width="200" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_07tfbe4_di" bpmnElement="TextAnnotation_07tfbe4">
+        <dc:Bounds x="150" y="424" width="170" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0x7whlg_di" bpmnElement="TextAnnotation_0x7whlg">
+        <dc:Bounds x="330" y="480" width="209.99998474121094" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/mappings/feel-100.bpmn
+++ b/test/fixtures/zeebe/mappings/feel-100.bpmn
@@ -1,0 +1,2009 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_feel_100" isExecutable="true">
+    <bpmn:scriptTask id="Activity_00">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_01">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_02">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_03">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_04">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_05">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_06">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_07">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_08">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_09">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_10">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_11">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_12">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_13">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_14">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_15">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_16">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_17">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_18">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_19">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_20">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_21">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_22">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_23">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_24">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_25">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_26">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_27">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_28">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_29">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result2" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_30">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_31">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_32">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_33">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_34">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_35">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_36">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_37">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_38">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_39">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_40">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_41">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_42">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_43">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_44">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_45">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_46">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_47">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_48">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_49">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result4" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_50">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_51">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_52">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_53">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_54">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_55">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_56">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_57">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_58">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_59">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result5" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_60">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_61">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_62">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_63">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_64">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_65">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_66">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_67">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_68">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_69">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result6" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_70">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_71">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_72">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_73">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_74">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_75">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_76">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_77">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_78">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_79">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result7" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_80">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_81">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_82">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_83">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_84">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_85">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_86">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_87">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_88">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_89">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result8" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_90">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_91">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_92">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_93">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_94">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_95">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_96">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_97">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_98">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_99">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b+c+sum([d,e])+sum([f,g])" resultVariable="result9" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="a" />
+          <zeebe:input source="=test" target="b" />
+          <zeebe:input source="=b" target="test" />
+          <zeebe:input source="=test" target="test2" />
+          <zeebe:input source="=a+b" target="test3" />
+          <zeebe:input source="=test2+test4" target="test4" />
+          <zeebe:input source="=12345" target="test5" />
+          <zeebe:input source="=432432" target="test6" />
+          <zeebe:input source="=test5" target="test6" />
+          <zeebe:input source="=test7" target="test7" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_feel_100">
+      <bpmndi:BPMNShape bpmnElement="Activity_00">
+        <dc:Bounds x="160" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_01">
+        <dc:Bounds x="260" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_02">
+        <dc:Bounds x="360" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_03">
+        <dc:Bounds x="460" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_04">
+        <dc:Bounds x="560" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_05">
+        <dc:Bounds x="660" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_06">
+        <dc:Bounds x="760" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_07">
+        <dc:Bounds x="860" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_08">
+        <dc:Bounds x="960" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_09">
+        <dc:Bounds x="1060" y="100" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_10">
+        <dc:Bounds x="160" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_11">
+        <dc:Bounds x="260" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_12">
+        <dc:Bounds x="360" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_13">
+        <dc:Bounds x="460" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_14">
+        <dc:Bounds x="560" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_15">
+        <dc:Bounds x="660" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_16">
+        <dc:Bounds x="760" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_17">
+        <dc:Bounds x="860" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_18">
+        <dc:Bounds x="960" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_19">
+        <dc:Bounds x="1060" y="200" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_20">
+        <dc:Bounds x="160" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_21">
+        <dc:Bounds x="260" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_22">
+        <dc:Bounds x="360" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_23">
+        <dc:Bounds x="460" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_24">
+        <dc:Bounds x="560" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_25">
+        <dc:Bounds x="660" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_26">
+        <dc:Bounds x="760" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_27">
+        <dc:Bounds x="860" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_28">
+        <dc:Bounds x="960" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_29">
+        <dc:Bounds x="1060" y="300" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_30">
+        <dc:Bounds x="160" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_31">
+        <dc:Bounds x="260" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_32">
+        <dc:Bounds x="360" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_33">
+        <dc:Bounds x="460" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_34">
+        <dc:Bounds x="560" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_35">
+        <dc:Bounds x="660" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_36">
+        <dc:Bounds x="760" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_37">
+        <dc:Bounds x="860" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_38">
+        <dc:Bounds x="960" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_39">
+        <dc:Bounds x="1060" y="400" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_40">
+        <dc:Bounds x="160" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_41">
+        <dc:Bounds x="260" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_42">
+        <dc:Bounds x="360" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_43">
+        <dc:Bounds x="460" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_44">
+        <dc:Bounds x="560" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_45">
+        <dc:Bounds x="660" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_46">
+        <dc:Bounds x="760" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_47">
+        <dc:Bounds x="860" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_48">
+        <dc:Bounds x="960" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_49">
+        <dc:Bounds x="1060" y="500" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_50">
+        <dc:Bounds x="160" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_51">
+        <dc:Bounds x="260" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_52">
+        <dc:Bounds x="360" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_53">
+        <dc:Bounds x="460" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_54">
+        <dc:Bounds x="560" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_55">
+        <dc:Bounds x="660" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_56">
+        <dc:Bounds x="760" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_57">
+        <dc:Bounds x="860" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_58">
+        <dc:Bounds x="960" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_59">
+        <dc:Bounds x="1060" y="600" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_60">
+        <dc:Bounds x="160" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_61">
+        <dc:Bounds x="260" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_62">
+        <dc:Bounds x="360" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_63">
+        <dc:Bounds x="460" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_64">
+        <dc:Bounds x="560" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_65">
+        <dc:Bounds x="660" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_66">
+        <dc:Bounds x="760" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_67">
+        <dc:Bounds x="860" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_68">
+        <dc:Bounds x="960" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_69">
+        <dc:Bounds x="1060" y="700" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_70">
+        <dc:Bounds x="160" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_71">
+        <dc:Bounds x="260" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_72">
+        <dc:Bounds x="360" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_73">
+        <dc:Bounds x="460" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_74">
+        <dc:Bounds x="560" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_75">
+        <dc:Bounds x="660" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_76">
+        <dc:Bounds x="760" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_77">
+        <dc:Bounds x="860" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_78">
+        <dc:Bounds x="960" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_79">
+        <dc:Bounds x="1060" y="800" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_80">
+        <dc:Bounds x="160" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_81">
+        <dc:Bounds x="260" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_82">
+        <dc:Bounds x="360" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_83">
+        <dc:Bounds x="460" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_84">
+        <dc:Bounds x="560" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_85">
+        <dc:Bounds x="660" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_86">
+        <dc:Bounds x="760" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_87">
+        <dc:Bounds x="860" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_88">
+        <dc:Bounds x="960" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_89">
+        <dc:Bounds x="1060" y="900" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_90">
+        <dc:Bounds x="160" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_91">
+        <dc:Bounds x="260" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_92">
+        <dc:Bounds x="360" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_93">
+        <dc:Bounds x="460" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_94">
+        <dc:Bounds x="560" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_95">
+        <dc:Bounds x="660" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_96">
+        <dc:Bounds x="760" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_97">
+        <dc:Bounds x="860" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_98">
+        <dc:Bounds x="960" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_99">
+        <dc:Bounds x="1060" y="1000" width="80" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/mappings/input-output-conflict.bpmn
+++ b/test/fixtures/zeebe/mappings/input-output-conflict.bpmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0-rc.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="InputTask" name="Input Task">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=foo" target="localFoo" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="OutputTask" name="Output Task">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=foo" target="otherLocal" />
+          <zeebe:output source="=result" target="foo" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="BPMNShape_1" bpmnElement="InputTask">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_2" bpmnElement="OutputTask">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/mappings/input-requirements.bpmn
+++ b/test/fixtures/zeebe/mappings/input-requirements.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0-rc.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="SimpleTask" name="Simple Input">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=a+b" target="sum" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="NestedTask" name="Nested Input">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=order.items" target="orderItems" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="MultiInputTask" name="Multi Input">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=x+y" target="result1" />
+          <zeebe:input source="=y+z" target="result2" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="MergedEntriesTask" name="Merged Entries">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=a.b" target="output1" />
+          <zeebe:input source="=a.c" target="output2" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="BPMNShape_1" bpmnElement="SimpleTask">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_2" bpmnElement="NestedTask">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_3" bpmnElement="MultiInputTask">
+        <dc:Bounds x="440" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_4" bpmnElement="MergedEntriesTask">
+        <dc:Bounds x="580" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/mappings/script-task-inputs.bpmn
+++ b/test/fixtures/zeebe/mappings/script-task-inputs.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:scriptTask id="firstTask">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=a+b" resultVariable="firstResult" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="firstTask" targetRef="secondTask" />
+    <bpmn:scriptTask id="secondTask">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=d+f" resultVariable="secondResult" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Shape_1" bpmnElement="firstTask">
+        <dc:Bounds x="150" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_2" bpmnElement="secondTask">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Edge_1" bpmnElement="Flow_1">
+        <di:waypoint x="250" y="120" />
+        <di:waypoint x="300" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/mappings/script-task-with-input-mappings.bpmn
+++ b/test/fixtures/zeebe/mappings/script-task-with-input-mappings.bpmn
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:scriptTask id="scriptWithInputs" name="Script with input mappings">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=processVar1" target="localA" />
+          <zeebe:input source="=processVar2 + 1" target="localB" />
+        </zeebe:ioMapping>
+        <zeebe:script expression="=localA + localB" resultVariable="scriptResult" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="scriptWithoutInputs" name="Script without input mappings">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=x + y" resultVariable="scriptResult2" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="chainedInputMappings" name="Chained input mappings">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=processVar3" target="localC" />
+          <zeebe:input source="=localC + 1" target="localD" />
+        </zeebe:ioMapping>
+        <zeebe:script expression="=localC + localD" resultVariable="chainedResult" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="shadowingTask" name="Shadowing a to a">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=a" target="a" />
+        </zeebe:ioMapping>
+        <zeebe:script expression="=a" resultVariable="shadowResult" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="shadowingChainedTask" name="Shadowing then chaining">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=a" target="a" />
+          <zeebe:input source="=a + 1" target="b" />
+        </zeebe:ioMapping>
+        <zeebe:script expression="=a + b" resultVariable="shadowChainResult" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="scriptUsesSecondInput" name="Script uses second input">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=def" target="abc" />
+          <zeebe:input source="=1" target="test" />
+        </zeebe:ioMapping>
+        <zeebe:script expression="=test" resultVariable="abc" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Shape_1" bpmnElement="scriptWithInputs">
+        <dc:Bounds x="150" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_2" bpmnElement="scriptWithoutInputs">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_3" bpmnElement="chainedInputMappings">
+        <dc:Bounds x="450" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_4" bpmnElement="shadowingTask">
+        <dc:Bounds x="600" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_5" bpmnElement="shadowingChainedTask">
+        <dc:Bounds x="750" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_6" bpmnElement="scriptUsesSecondInput">
+        <dc:Bounds x="900" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/read-write.bpmn
+++ b/test/fixtures/zeebe/read-write.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kvhh4n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" name="Write: approved" isExecutable="true">
+    <bpmn:serviceTask id="ValidateApprovedTask" name="Validate Approved">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=approved" target="localApproved" />
+          <zeebe:output source="=localApproved" target="approved" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:textAnnotation id="TextAnnotation_12joy1t">
+      <bpmn:text>Write: approved</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1x9i5o6" associationDirection="None" sourceRef="ValidateApprovedTask" targetRef="TextAnnotation_12joy1t" />
+    <bpmn:textAnnotation id="TextAnnotation_0cyrq9q">
+      <bpmn:text>Read: approved</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1qg1o3f" associationDirection="None" sourceRef="TextAnnotation_0cyrq9q" targetRef="ValidateApprovedTask" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_13wsimk_di" bpmnElement="ValidateApprovedTask">
+        <dc:Bounds x="240" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1x9i5o6_di" bpmnElement="Association_1x9i5o6">
+        <di:waypoint x="328" y="170" />
+        <di:waypoint x="386" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1qg1o3f_di" bpmnElement="Association_1qg1o3f">
+        <di:waypoint x="201" y="110" />
+        <di:waypoint x="244" y="172" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_12joy1t_di" bpmnElement="TextAnnotation_12joy1t">
+        <dc:Bounds x="350" y="80" width="120" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1n8m9kv" bpmnElement="TextAnnotation_0cyrq9q">
+        <dc:Bounds x="160" y="80" width="130" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/read-write.hierarchical.bpmn
+++ b/test/fixtures/zeebe/read-write.hierarchical.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kvhh4n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ValidateApprovedTask" name="Validate Approved">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=application.approved" target="localApproved" />
+          <zeebe:output source="=localApproved" target="application.approved" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:textAnnotation id="TextAnnotation_12joy1t">
+      <bpmn:text>Write: application.approved</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1x9i5o6" associationDirection="None" sourceRef="ValidateApprovedTask" targetRef="TextAnnotation_12joy1t" />
+    <bpmn:textAnnotation id="TextAnnotation_0cyrq9q">
+      <bpmn:text>Read: application.approved</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1qg1o3f" associationDirection="None" sourceRef="TextAnnotation_0cyrq9q" targetRef="ValidateApprovedTask" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_13wsimk_di" bpmnElement="ValidateApprovedTask">
+        <dc:Bounds x="290" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1qg1o3f_di" bpmnElement="Association_1qg1o3f">
+        <di:waypoint x="249" y="106" />
+        <di:waypoint x="294" y="172" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1x9i5o6_di" bpmnElement="Association_1x9i5o6">
+        <di:waypoint x="378" y="170" />
+        <di:waypoint x="436" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_12joy1t_di" bpmnElement="TextAnnotation_12joy1t">
+        <dc:Bounds x="400" y="80" width="170" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1n8m9kv" bpmnElement="TextAnnotation_0cyrq9q">
+        <dc:Bounds x="160" y="80" width="170" height="25.999998092651367" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/used-variables.bpmn
+++ b/test/fixtures/zeebe/used-variables.bpmn
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19hmm0v" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="StartEvent_1" targetRef="TriggerCheckTask" />
+    <bpmn:startEvent id="StartEvent_1" name="New subscription request">
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_06kuoon" messageRef="SUBSCRIPTION_REQUEST_MESSAGE" />
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="TriggerCheckTask" name="Trigger check">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1" name="Is age verified" default="SequenceFlow_4">
+      <bpmn:incoming>SequenceFlow_3</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_4</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_3" sourceRef="TriggerCheckTask" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_1" name="Yes" sourceRef="Gateway_1" targetRef="Gateway_2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isAgeVerified</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_4" sourceRef="Gateway_1" targetRef="VerifyAgeTask" />
+    <bpmn:receiveTask id="VerifyAgeTask" name="Verify Age" messageRef="AGE_VERIFIED_MESSAGE">
+      <bpmn:incoming>SequenceFlow_4</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_5</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:exclusiveGateway id="Gateway_2">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_5</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_6</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_6" sourceRef="Gateway_2" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="SequenceFlow_5" sourceRef="VerifyAgeTask" targetRef="Gateway_2" />
+    <bpmn:exclusiveGateway id="Gateway_3" name="Can create subscription?" default="SequenceFlow_7">
+      <bpmn:incoming>SequenceFlow_6</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_10</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_10" name="Yes" sourceRef="Gateway_1" targetRef="CreateSubscriptionTask">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isAgeVerified and is empty(checkResults)</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_7" sourceRef="Gateway_1" targetRef="Send_Rejection" />
+    <bpmn:serviceTask id="CreateSubscriptionTask" name="Create Subscription">
+      <bpmn:incoming>SequenceFlow_10</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_9</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_2" name="Subscription created">
+      <bpmn:incoming>SequenceFlow_9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_9" sourceRef="CreateSubscriptionTask" targetRef="EndEvent_2" />
+    <bpmn:serviceTask id="Send_Rejection" name="Send Rejection">
+      <bpmn:incoming>SequenceFlow_7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_8</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="Rejected">
+      <bpmn:incoming>SequenceFlow_8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_8" sourceRef="Send_Rejection" targetRef="EndEvent_1" />
+    <bpmn:textAnnotation id="TextAnnotation_1id10go">
+      <bpmn:text>This process models a typical pro-code scenario where the data model is implicit ("in code")
+
+* variables are only used, never written in the model
+* intelligence should indicate variables used</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmn:message id="SUBSCRIPTION_REQUEST_MESSAGE" name="SUBSCRIPTION_REQUEST_MESSAGE" />
+  <bpmn:message id="AGE_VERIFIED_MESSAGE" name="AGE_VERIFIED">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=subscriptionRequestID" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_0g6g003_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="345" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TriggerCheckTask_di" bpmnElement="TriggerCheckTask">
+        <dc:Bounds x="270" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="425" y="295" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="416" y="265" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="VerifyAgeTask_di" bpmnElement="VerifyAgeTask">
+        <dc:Bounds x="500" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_2_di" bpmnElement="Gateway_2" isMarkerVisible="true">
+        <dc:Bounds x="655" y="295" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_3_di" bpmnElement="Gateway_3" isMarkerVisible="true">
+        <dc:Bounds x="755" y="295" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="747" y="258" width="65" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CreateSubscriptionTask_di" bpmnElement="CreateSubscriptionTask">
+        <dc:Bounds x="870" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Send_Rejection_di" bpmnElement="Send_Rejection">
+        <dc:Bounds x="870" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_2_di" bpmnElement="EndEvent_2">
+        <dc:Bounds x="1032" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1020" y="345" width="61" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1032" y="412" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1028" y="455" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="218" y="320" />
+        <di:waypoint x="270" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_3_di" bpmnElement="SequenceFlow_3">
+        <di:waypoint x="370" y="320" />
+        <di:waypoint x="425" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="475" y="320" />
+        <di:waypoint x="655" y="320" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="493" y="293" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_4_di" bpmnElement="SequenceFlow_4">
+        <di:waypoint x="450" y="345" />
+        <di:waypoint x="450" y="430" />
+        <di:waypoint x="500" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_6_di" bpmnElement="SequenceFlow_6">
+        <di:waypoint x="705" y="320" />
+        <di:waypoint x="755" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_5_di" bpmnElement="SequenceFlow_5">
+        <di:waypoint x="600" y="430" />
+        <di:waypoint x="680" y="430" />
+        <di:waypoint x="680" y="345" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10_di" bpmnElement="SequenceFlow_10">
+        <di:waypoint x="805" y="320" />
+        <di:waypoint x="870" y="320" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="829" y="302" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_7_di" bpmnElement="SequenceFlow_7">
+        <di:waypoint x="780" y="345" />
+        <di:waypoint x="780" y="430" />
+        <di:waypoint x="870" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_9_di" bpmnElement="SequenceFlow_9">
+        <di:waypoint x="970" y="320" />
+        <di:waypoint x="1032" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_8_di" bpmnElement="SequenceFlow_8">
+        <di:waypoint x="970" y="430" />
+        <di:waypoint x="1032" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_1id10go_di" bpmnElement="TextAnnotation_1id10go" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="350" y="80" width="375" height="84" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/used-variables.scopes.bpmn
+++ b/test/fixtures/zeebe/used-variables.scopes.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kvhh4n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" name="Process_1" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" name="SubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input target="approved" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_03u12aa</bpmn:outgoing>
+      <bpmn:scriptTask id="Task_2" name="Task_2">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=if approved then 1 else 0" resultVariable="taskResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_03u12aa" sourceRef="SubProcess_1" targetRef="Task_1" />
+    <bpmn:scriptTask id="Task_1" name="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=if approved then &#34;APPROVED&#34; else &#34;NOT APPROVED&#34;" resultVariable="taskResult" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_03u12aa</bpmn:incoming>
+    </bpmn:scriptTask>
+    <bpmn:textAnnotation id="TextAnnotation_06v37so">
+      <bpmn:text>Defines &lt;approved&gt; as local variable</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1vyzo9d" associationDirection="None" sourceRef="SubProcess_1" targetRef="TextAnnotation_06v37so" />
+    <bpmn:textAnnotation id="TextAnnotation_1gqpt1k">
+      <bpmn:text>Uses &lt;approved&gt; variable</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1613yyk" associationDirection="None" sourceRef="TextAnnotation_1gqpt1k" targetRef="Task_1" />
+    <bpmn:association id="Association_15s62zn" associationDirection="None" sourceRef="TextAnnotation_1gqpt1k" targetRef="Task_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0rpc80a_di" bpmnElement="Task_1">
+        <dc:Bounds x="570" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13kwa1s_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="160" y="210" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0azqo33_di" bpmnElement="Task_2">
+        <dc:Bounds x="220" y="270" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1613yyk_di" bpmnElement="Association_1613yyk">
+        <di:waypoint x="480" y="530" />
+        <di:waypoint x="613" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1vyzo9d_di" bpmnElement="Association_1vyzo9d">
+        <di:waypoint x="347" y="210" />
+        <di:waypoint x="355" y="135" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_15s62zn_di" bpmnElement="Association_15s62zn">
+        <di:waypoint x="436" y="530" />
+        <di:waypoint x="279" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_06v37so_di" bpmnElement="TextAnnotation_06v37so">
+        <dc:Bounds x="310" y="80" width="100" height="54.999996185302734" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0u3y3b2" bpmnElement="TextAnnotation_1gqpt1k">
+        <dc:Bounds x="410" y="530" width="110" height="50" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_03u12aa_di" bpmnElement="Flow_03u12aa">
+        <di:waypoint x="510" y="310" />
+        <di:waypoint x="570" y="310" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/zeebe/Mappings.spec.js
+++ b/test/spec/zeebe/Mappings.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import TestContainer from 'mocha-test-container-support';
 
@@ -13,6 +14,7 @@ import { ZeebeVariableResolverModule } from 'lib/';
 
 import chainedMappingsXML from 'test/fixtures/zeebe/mappings/chained-mappings.bpmn';
 import chainedMappingsAnyXML from 'test/fixtures/zeebe/mappings/chained-mappings.any.bpmn';
+import consumedVariablesXML from 'test/fixtures/zeebe/mappings/input-requirements.bpmn';
 import primitivesXML from 'test/fixtures/zeebe/mappings/primitives.bpmn';
 import mergingXML from 'test/fixtures/zeebe/mappings/merging.bpmn';
 import mergingChildrenXML from 'test/fixtures/zeebe/mappings/merging.children.bpmn';
@@ -25,6 +27,10 @@ import scriptTaskXML from 'test/fixtures/zeebe/mappings/script-task.bpmn';
 import scriptTaskEmptyExpressionXML from 'test/fixtures/zeebe/mappings/script-task-empty-expression.bpmn';
 import scriptTaskOutputNoNameXML from 'test/fixtures/zeebe/mappings/script-task-output-no-name.bpmn';
 import unresolvablePathExpressionXML from 'test/fixtures/zeebe/mappings/unresolvable-path-expression.bpmn';
+import scriptTaskInputsXML from 'test/fixtures/zeebe/mappings/script-task-inputs.bpmn';
+import scriptTaskWithInputMappingsXML from 'test/fixtures/zeebe/mappings/script-task-with-input-mappings.bpmn';
+import inputOutputConflictXML from 'test/fixtures/zeebe/mappings/input-output-conflict.bpmn';
+import emptyXML from 'test/fixtures/zeebe/empty.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
 
@@ -914,6 +920,667 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
     });
   });
 
+
+  describe('Consumed Variables', function() {
+
+    beforeEach(bootstrap(consumedVariablesXML));
+
+
+    it('should extract input variables from simple expression', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('SimpleTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'a', usedBy: [ 'SimpleTask' ] },
+        { name: 'b', usedBy: [ 'SimpleTask' ] }
+      ]);
+    }));
+
+
+    it('should extract input variables with nested properties', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('NestedTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableInclude({
+        name: 'order',
+        entries: [ { name: 'items' } ],
+        usedBy: [ 'NestedTask' ]
+      });
+    }));
+
+
+    it('should deduplicate input variables across mappings', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('MultiInputTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then - y is used in both input mappings but should only appear once
+      const yVars = variables.filter(v => v.name === 'y');
+      expect(yVars).to.have.length(1);
+    }));
+
+
+    it('should extract all unique input variables from multiple mappings', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('MultiInputTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableInclude([
+        { name: 'x' },
+        { name: 'y' },
+        { name: 'z' }
+      ]);
+    }));
+
+
+    it('should merge entries from multiple expressions referencing the same variable', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('MergedEntriesTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then - a.b and a.c should result in a: { entries: [b, c] }
+      expect(variables).to.variableInclude({
+        name: 'a',
+        entries: [
+          { name: 'b' },
+          { name: 'c' }
+        ]
+      });
+    }));
+
+
+    it('should scope consumed variables to the origin task', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('SimpleTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then - a originates from SimpleTask (the task with the input mapping)
+      const a = variables.find(v => v.name === 'a');
+      expect(a).to.exist;
+      expect(a.scope).to.not.exist;
+    }));
+
+
+    it('should keep provider and extracted variables separate', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+      const task = elementRegistry.get('SimpleTask');
+
+      createProvider({
+        variables: [ { name: 'a', type: 'Number', scope: root } ],
+        variableResolver
+      });
+
+      // when - getVariables should have the scoped provider variable
+      const variables = (await variableResolver.getVariables())['Process_1'];
+      const scopedA = variables.find(v => v.name === 'a' && v.scope);
+      expect(scopedA).to.exist;
+
+      // and a read-only query should have the unscoped consumed variable
+      const consumed = await getReadVariablesForElement(variableResolver, task);
+      const unscopedA = consumed.find(v => v.name === 'a' && !v.scope);
+      expect(unscopedA).to.exist;
+    }));
+
+  });
+
+
+  describe('Consumed Variables - Input/Output Conflict', function() {
+
+    beforeEach(bootstrap(inputOutputConflictXML));
+
+
+    it('should extract consumed variable from input mapping when another task has output mapping with same name', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const inputTask = elementRegistry.get('InputTask');
+      const outputTask = elementRegistry.get('OutputTask');
+
+      // when
+      const inputReqs = await getReadVariablesForElement(variableResolver, inputTask);
+      const outputReqs = await getReadVariablesForElement(variableResolver, outputTask);
+
+      // then - foo is used in the input mapping of both tasks
+      expect(inputReqs).to.variableInclude({ name: 'foo' });
+      expect(outputReqs).to.variableInclude({ name: 'foo' });
+    }));
+
+
+    it('should return foo as read variable for InputTask', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('InputTask');
+
+      // when
+      const requirements = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(requirements).to.variableInclude({ name: 'foo' });
+    }));
+
+
+    it('should return foo as read variable for OutputTask', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('OutputTask');
+
+      // when
+      const requirements = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(requirements).to.variableInclude({ name: 'foo' });
+    }));
+
+  });
+
+
+  describe('Consumed Variables - Script Tasks', function() {
+
+    beforeEach(bootstrap(scriptTaskInputsXML));
+
+
+    it('should extract input variables from script task expression', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('firstTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'a', usedBy: [ 'firstTask' ] },
+        { name: 'b', usedBy: [ 'firstTask' ] }
+      ]);
+    }));
+
+
+    it('should extract input variables from second script task', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('secondTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'd', usedBy: [ 'secondTask' ] },
+        { name: 'f', usedBy: [ 'secondTask' ] }
+      ]);
+    }));
+
+
+    it('should not include consumed variables in getVariablesForElement', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const firstTask = elementRegistry.get('firstTask');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(firstTask);
+
+      // then - consumed variables (a, b, d, f) should not appear since they have no scope
+      const names = variables.map(v => v.name);
+      expect(names).to.not.include('a');
+      expect(names).to.not.include('b');
+      expect(names).to.not.include('d');
+      expect(names).to.not.include('f');
+    }));
+
+  });
+
+
+  describe('Consumed Variables - Script Task with Input Mappings', function() {
+
+    beforeEach(bootstrap(scriptTaskWithInputMappingsXML));
+
+
+    it('should extract consumed variables from input mapping expressions but not from script for locally mapped variables', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('scriptWithInputs');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableInclude([
+        { name: 'processVar1' },
+        { name: 'processVar2' }
+      ]);
+
+      const names = variables.map(v => v.name);
+      expect(names).to.not.include('localA');
+      expect(names).to.not.include('localB');
+    }));
+
+
+    it('should still extract consumed variables from script without input mappings', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('scriptWithoutInputs');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableInclude([
+        { name: 'x' },
+        { name: 'y' }
+      ]);
+    }));
+
+
+    it('should not require locally provided variable when chained input mapping references earlier target', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('chainedInputMappings');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableInclude({ name: 'processVar3' });
+
+      const names = variables.map(v => v.name);
+      expect(names).to.not.include('localC');
+      expect(names).to.not.include('localD');
+    }));
+
+
+    it('should keep shadowed variable as consumed variable when mapping a to a', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('shadowingTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableInclude({ name: 'a' });
+    }));
+
+
+    it('should handle shadowing with chaining correctly', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('shadowingChainedTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableInclude({ name: 'a' });
+
+      const names = variables.map(v => v.name);
+      expect(names).to.not.include('b');
+    }));
+
+
+    it('should not require second input mapping variable used in script', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('scriptUsesSecondInput');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'def' }
+      ]);
+    }));
+
+
+    it('should annotate locally-provided input mapping variables with usedBy', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('scriptWithInputs');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then - localA and localB should have usedBy pointing to scriptResult
+      expect(variables).to.variableInclude([
+        { name: 'localA' },
+        { name: 'localB' }
+      ]);
+
+      const localA = variables.find(v => v.name === 'localA');
+      const localB = variables.find(v => v.name === 'localB');
+      expect(localA.usedBy.map(usage => usage.id)).to.eql([ task.id ]);
+      expect(localB.usedBy.map(usage => usage.id)).to.eql([ task.id ]);
+    }));
+
+
+    it('should annotate chained input mapping variables with usedBy', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('chainedInputMappings');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then - localC is used by both localD and chainedResult
+      const localC = variables.find(v => v.name === 'localC');
+      const localD = variables.find(v => v.name === 'localD');
+      expect(localC).to.exist;
+      expect(localC.usedBy.map(usage => usage.id)).to.eql([ task.id ]);
+      expect(localD).to.exist;
+      expect(localD.usedBy.map(usage => usage.id)).to.eql([ task.id ]);
+    }));
+
+
+    it('should not add usedBy for variables without input mappings', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('scriptWithoutInputs');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then - scriptResult2 should not have usedBy (it has no input mappings)
+      const scriptResult2 = variables.find(v => v.name === 'scriptResult2');
+      expect(scriptResult2).to.exist;
+      expect(scriptResult2.usedBy).to.not.exist;
+    }));
+
+  });
+
+
+  describe('#getVariablesForElement (read filter)', function() {
+
+    describe('with input mappings', function() {
+
+      beforeEach(bootstrap(consumedVariablesXML));
+
+
+      it('should return consumed variables for a simple task', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('SimpleTask');
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver, task);
+
+        // then - both 'a' and 'b' are consumed variables for SimpleTask
+        expect(requirements).to.variableEqual([
+          { name: 'a' },
+          { name: 'b' }
+        ]);
+      }));
+
+
+      it('should return requirements with nested properties', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('NestedTask');
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver, task);
+
+        // then
+        expect(requirements).to.variableEqual([
+          { name: 'order', entries: [ { name: 'items' } ] }
+        ]);
+      }));
+
+
+      it('should return requirements from multiple input mappings', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('MultiInputTask');
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver, task);
+
+        // then
+        expect(requirements).to.variableInclude([
+          { name: 'x' },
+          { name: 'y' },
+          { name: 'z' }
+        ]);
+      }));
+
+
+      it('should return empty array for element without consumed variables', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const process = elementRegistry.get('Process_1');
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver, process);
+
+        // then
+        expect(requirements).to.be.an('array').that.is.empty;
+      }));
+
+
+      it('should not return variables from other elements', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('SimpleTask');
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver, task);
+
+        // then - should not include variables from MultiInputTask or NestedTask
+        expect(requirements).to.variableEqual([
+          { name: 'a' },
+          { name: 'b' }
+        ]);
+      }));
+
+
+      it('should return consumed variables even when other tasks use the same variable', inject(async function(variableResolver, elementRegistry) {
+
+        // given - MergedEntriesTask uses 'a' which is also used by SimpleTask
+        // Consumed variables are per-task and should not be merged
+        const task = elementRegistry.get('MergedEntriesTask');
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver, task);
+
+        // then
+        expect(requirements).to.variableEqual([
+          { name: 'a', entries: [ { name: 'b' }, { name: 'c' } ] }
+        ]);
+      }));
+
+    });
+
+
+    describe('with script tasks', function() {
+
+      beforeEach(bootstrap(scriptTaskInputsXML));
+
+
+      it('should return consumed variables for script task', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('firstTask');
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver, task);
+
+        // then
+        expect(requirements).to.variableInclude([
+          { name: 'a' },
+          { name: 'b' }
+        ]);
+      }));
+
+
+      it('should only return requirements for the requested task', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('secondTask');
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver, task);
+
+        // then
+        expect(requirements).to.variableInclude([
+          { name: 'd' },
+          { name: 'f' }
+        ]);
+
+        const names = requirements.map(v => v.name);
+        expect(names).to.not.include('a');
+        expect(names).to.not.include('b');
+      }));
+
+    });
+
+
+    describe('with script tasks and input mappings', function() {
+
+      beforeEach(bootstrap(scriptTaskWithInputMappingsXML));
+
+
+      it('should only return process variables as consumed variables, not locally mapped ones', inject(async function(variableResolver, elementRegistry) {
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver,
+          elementRegistry.get('scriptWithInputs')
+        );
+
+        // then
+        expect(requirements).to.variableEqual([
+          { name: 'processVar1' },
+          { name: 'processVar2' }
+        ]);
+      }));
+
+
+      it('should return all script variables for task without input mappings', inject(async function(variableResolver, elementRegistry) {
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver,
+          elementRegistry.get('scriptWithoutInputs')
+        );
+
+        // then
+        expect(requirements).to.variableEqual([
+          { name: 'x' },
+          { name: 'y' }
+        ]);
+      }));
+
+
+      it('should handle chained input mappings respecting order', inject(async function(variableResolver, elementRegistry) {
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver,
+          elementRegistry.get('chainedInputMappings')
+        );
+
+        // then
+        expect(requirements).to.variableEqual([
+          { name: 'processVar3' }
+        ]);
+      }));
+
+
+      it('should keep shadowed variable as requirement when mapping a to a', inject(async function(variableResolver, elementRegistry) {
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver,
+          elementRegistry.get('shadowingTask')
+        );
+
+        // then
+        expect(requirements).to.variableEqual([
+          { name: 'a' }
+        ]);
+      }));
+
+
+      it('should handle shadowing with chained mappings', inject(async function(variableResolver, elementRegistry) {
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver,
+          elementRegistry.get('shadowingChainedTask')
+        );
+
+        // then
+        expect(requirements).to.variableEqual([
+          { name: 'a' }
+        ]);
+      }));
+
+
+      it('should allow script to use all input targets regardless of order', inject(async function(variableResolver, elementRegistry) {
+
+        // when
+        const requirements = await getReadVariablesForElement(variableResolver,
+          elementRegistry.get('scriptUsesSecondInput')
+        );
+
+        // then
+        expect(requirements).to.variableEqual([
+          { name: 'def' }
+        ]);
+      }));
+
+    });
+
+
+    describe('error handling', function() {
+
+      beforeEach(bootstrap(emptyXML));
+
+
+      it('should reject when getVariables fails', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const process = elementRegistry.get('Process_1');
+        sinon.stub(variableResolver, 'getVariables').rejects(new Error('test error'));
+
+        // when
+        // then
+        let error;
+
+        try {
+          await getReadVariablesForElement(variableResolver, process);
+        } catch (err) {
+          error = err;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.eql('test error');
+
+        variableResolver.getVariables.restore();
+      }));
+
+    });
+
+  });
+
 });
 
 // helpers //////////////////////
@@ -931,6 +1598,16 @@ const createProvider = function({ variables, variableResolver, origin }) {
     }
   }(variableResolver);
 };
+
+async function getReadVariablesForElement(variableResolver, element) {
+  const variables = await variableResolver.getVariablesForElement(element, {
+    read: true,
+    written: false
+  });
+
+  // Preserve old consumed-only test semantics: consumed variables are unscoped.
+  return variables.filter(variable => !variable.scope);
+}
 
 function toVariableFormat(variables) {
   return Object.keys(variables).map(v => {

--- a/test/spec/zeebe/Performance.spec.js
+++ b/test/spec/zeebe/Performance.spec.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import { bootstrapModeler, getBpmnJS } from 'test/TestHelper';
+
+import { ZeebeVariableResolverModule } from 'lib/';
+
+import feel100 from 'test/fixtures/zeebe/mappings/feel-100.bpmn';
+
+const ITERATIONS = 5;
+
+describe('ZeebeVariableResolver - Performance', function() {
+
+  const bootstrap = bootstrapModeler(feel100, {
+    additionalModules: [
+      ZeebeVariableResolverModule
+    ],
+    moddleExtensions: {
+      zeebe: ZeebeModdle
+    }
+  });
+
+  it('performance should not decrease significantly', async function() {
+
+    let totalDuration = 0;
+
+    for (let index = 0; index < ITERATIONS; index++) {
+      const start = performance.now();
+      await bootstrap.call(this);
+      const variableResolver = getBpmnJS().get('variableResolver');
+      await variableResolver.getVariables();
+      const end = performance.now();
+      const duration = end - start;
+
+      totalDuration += duration;
+    }
+
+    const averageDuration = totalDuration / ITERATIONS;
+    expect(averageDuration).to.be.lessThan(300);
+  });
+
+});

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -32,6 +32,11 @@ import subprocessNoOutputMappingXML from 'test/fixtures/zeebe/sub-process.no-out
 import longBrokenExpressionXML from 'test/fixtures/zeebe/long-broken-expression.bpmn';
 import immediatelyBrokenExpressionXML from 'test/fixtures/zeebe/immediately-broken-expression.bpmn';
 import typeResolutionXML from 'test/fixtures/zeebe/type-resolution.bpmn';
+import usedVariablesXML from 'test/fixtures/zeebe/used-variables.bpmn';
+import usedVariablesScopesXML from 'test/fixtures/zeebe/used-variables.scopes.bpmn';
+import readWriteXML from 'test/fixtures/zeebe/read-write.bpmn';
+import readWriteHierarchicalXML from 'test/fixtures/zeebe/read-write.hierarchical.bpmn';
+import filteringXML from 'test/fixtures/zeebe/filtering.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
 import { getInputOutput } from '../../../lib/base/util/ExtensionElementsUtil';
@@ -2659,6 +2664,335 @@ describe('ZeebeVariableResolver', function() {
       }));
 
     });
+
+  });
+
+
+  describe('used variables - scopes', function() {
+
+    beforeEach(bootstrapModeler(usedVariablesScopesXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should attach <usedBy> to local scope', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const subProcess = elementRegistry.get('SubProcess_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(subProcess);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskResult' },
+        { name: 'approved', usedBy: [ 'Task_2' ] }
+      ]);
+    }));
+
+
+    it('should attach <usedBy> to global scope', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const rootElement = elementRegistry.get('Process_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(rootElement);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskResult' },
+        { name: 'approved', usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+  });
+
+
+  describe('used variables - pro code', function() {
+
+    beforeEach(bootstrapModeler(usedVariablesXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should expose used variables globally', inject(async function(elementRegistry, variableResolver) {
+
+      // when
+      const allVariables = await variableResolver.getVariables();
+
+      // then
+      expect(allVariables).to.have.property('Process_1');
+
+      expect(allVariables['Process_1']).to.variableEqual([
+        { name: 'isAgeVerified', usedBy: [ 'SequenceFlow_1', 'SequenceFlow_10' ], scope: undefined, origin: undefined },
+        { name: 'subscriptionRequestID', usedBy: [ 'VerifyAgeTask' ], scope: undefined, origin: undefined },
+        { name: 'checkResults', usedBy: [ 'SequenceFlow_10' ], scope: undefined, origin: undefined }
+      ]);
+
+      // and when
+      const rootElement = elementRegistry.get('Process_1');
+
+      const processVariables = await variableResolver.getProcessVariables(rootElement);
+
+      expect(processVariables).to.eql(allVariables['Process_1']);
+    }));
+
+
+    describe('should expose used variables per element', function() {
+
+      it('sequence flow', inject(async function(elementRegistry, variableResolver) {
+
+        // when
+        const flow = elementRegistry.get('SequenceFlow_1');
+
+        const variables = await variableResolver.getVariablesForElement(flow);
+
+        // then
+        expect(variables).to.variableEqual([
+          { name: 'isAgeVerified', usedBy: [ 'SequenceFlow_1', 'SequenceFlow_10' ], scope: undefined, origin: undefined }
+        ]);
+      }));
+
+
+      it('receive task', inject(async function(elementRegistry, variableResolver) {
+
+        // when
+        const task = elementRegistry.get('VerifyAgeTask');
+
+        const variables = await variableResolver.getVariablesForElement(task);
+
+        // then
+        expect(variables).to.variableEqual([
+          { name: 'subscriptionRequestID', usedBy: [ 'VerifyAgeTask' ], scope: undefined, origin: undefined }
+        ]);
+      }));
+
+
+      it('process', inject(async function(elementRegistry, variableResolver) {
+
+        // when
+        const rootElement = elementRegistry.get('Process_1');
+
+        const variables = await variableResolver.getVariablesForElement(rootElement);
+
+        // then
+        // TODO(nikku): should that include variables not used by process?
+        expect(variables).to.variableEqual([]);
+      }));
+
+    });
+
+  });
+
+
+  describe('used variables - read and written', function() {
+
+    beforeEach(bootstrapModeler(readWriteXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should indicate dual use', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('ValidateApprovedTask');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'approved', scope: 'Process_1', origin: [ 'ValidateApprovedTask' ], usedBy: [ 'ValidateApprovedTask' ] },
+        { name: 'localApproved', scope: 'ValidateApprovedTask' }
+      ]);
+    }));
+
+  });
+
+
+  describe('used variables - read and written / hierarchical', function() {
+
+    beforeEach(bootstrapModeler(readWriteHierarchicalXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should indicate dual use', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('ValidateApprovedTask');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'application', scope: 'Process_1', origin: [ 'ValidateApprovedTask' ], usedBy: [ 'ValidateApprovedTask' ] },
+        { name: 'localApproved', scope: 'ValidateApprovedTask' }
+      ]);
+    }));
+
+  });
+
+
+  describe('filtering', function() {
+
+    beforeEach(bootstrapModeler(filteringXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+    it('should filter read of global variables', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('SubProcess_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { written:false, local:false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'globalFoo', scope: undefined, usedBy: [ 'SubProcess_1' ] }
+      ]);
+    }));
+
+    it('should NOT filter', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'subFoo', scope: 'SubProcess_1', origin: [ 'SubProcess_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'taskResult', scope: 'Process_1', origin: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter read', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { written: false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'subFoo', scope: 'SubProcess_1', origin: [ 'SubProcess_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter read / local', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { written: false, external: false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter read / global', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { written: false, local: false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'subFoo', scope: 'SubProcess_1', origin: [ 'SubProcess_1' ], usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter write', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { read: false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'taskResult', scope: 'Process_1', origin: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter written / local', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { read: false, external: false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter written / global', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { read: false, local: false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskResult', scope: 'Process_1', origin: [ 'Task_1' ] }
+      ]);
+    }));
 
   });
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5639

### Proposed Changes

- getVariables now also includec scopeless (=> read) variables
- getVariablesForElement can now take an optional filter object (defaults to true for all) to reuse common filtering tasks to differentiate between read/written and local/external variables

different consumers:
```
npx @bpmn-io/sr camunda/task-testing#update-variable-resolver-v3 -l bpmn-io/variable-resolver#5639_variable-input-requirements

npx @bpmn-io/sr bpmn-io/variable-outline#update-variable-resolver-v3 -l bpmn-io/variable-resolver#5639_variable-input-requirements
```

follow up PRs: 
- https://github.com/bpmn-io/variable-outline/pull/50
- https://github.com/camunda/task-testing/pull/87
- https://github.com/camunda/camunda-bpmn-js/pull/454

<!--
runs feel-analyzer on every input "feel" expression (input mapping starting with `=` and scripts) and adds them to raw variables without scope

new function `getInputRequirementsForElement` can be used by consumers to get those variables

variables without scope are filtered out of the normal `getVariables`

Probably best to try out in task testing demo:

npx @bpmn-io/sr camunda/task-testing#5640_prefill-tasktesting -l bpmn-io/variable-resolver#5639_variable-input-requirements


Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
