### PR TITLE
fix: ensure variables have names

### DIFF
--- a/lib/base/VariableResolver.js
+++ b/lib/base/VariableResolver.js
@@ -119,8 +119,11 @@ export class BaseVariableResolver {
 
       const elementVariables = await this._baseExtractor(element, [ this._extractor.bind(this) ]);
 
+      // Filter out variables without a name
+      const validVariables = elementVariables.filter(variable => variable.name);
+
       // Annotate variables with extractor information
-      variables[element.id] = elementVariables.map(variable => {
+      variables[element.id] = validVariables.map(variable => {
         if (!variable.provider) {
           variable.provider = [ this._baseExtractor ];
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
       "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -522,7 +521,6 @@
       "integrity": "sha512-TWlZ3Z2DlzZzVGM7hZUVxd7P+KCUcrXGVKbaII/5IEQyjiiX34VkJRVGp86k7fRf0vgIKjPcPTHKpoYSthld7g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bpmn-io/feel-editor": "^2.5.0",
         "@carbon/icons": "^11.69.0",
@@ -1243,6 +1241,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1252,6 +1251,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
       "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -1261,6 +1261,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
       "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
@@ -1272,6 +1273,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
       "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1280,7 +1282,8 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
@@ -1555,7 +1558,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2208,7 +2210,6 @@
       "integrity": "sha512-Dg2O+r7jpBwLgWGpManc7P4ZfZQfxTVi2xNtXR3Q2G5Hx1RVYVFoNsQED8+FPCgjy6m7ZQbxKP1sjCJt5rbtBg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
         "diagram-js": "^15.9.0",
@@ -2272,7 +2273,6 @@
       "integrity": "sha512-XrorbMXf2SQuGIIPQDMTCQU6a5G64ryStU5SFomYdkYWKUvz9Kw+5A2skF5duNjfs48VerLlW9Avq7jOsjJZgg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^2.0.0",
         "array-move": "^4.0.0",
@@ -2386,7 +2386,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2470,7 +2469,6 @@
       "integrity": "sha512-Brbt6ZY+SklZjc77R4WKyBqmLXshcvAJVGIabvQUKqn6IDzClGRlTX/V2aaIC9OyMFuXJRQSd3zYrbZRQHk9vg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ids": "^3.0.0",
         "min-dash": "^5.0.0"
@@ -2485,8 +2483,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
       "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001759",
@@ -2515,7 +2512,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3019,8 +3015,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
       "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -3034,7 +3029,6 @@
       "integrity": "sha512-9FRoItWkrZnGalrqs0ekwS9wSuHQI2dzO+kJyHKa1hhMJPMBGrjR/cg0XMTpaLo2Vu9/gKL1o19P3sN4/YmIAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.1",
@@ -3082,6 +3076,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -3456,7 +3451,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5399,7 +5393,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/karma": {
       "version": "6.4.4",
@@ -5622,7 +5617,8 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6180,7 +6176,6 @@
       "integrity": "sha512-ZjE3D0EtU3Qp6ZpxBckGFydIQi++feYvhvxhjNYKGzlC8+2lpcO0lS86WC/B+s2lbAqjrlOMYCQqu6mHAtz2cg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "min-dash": "^5.0.0"
       }
@@ -6255,6 +6250,7 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.7.tgz",
       "integrity": "sha512-wWtNUhkT7k58uvWTB/Gy26eA/EJKtPZFVAhEilN5UYVmmGRYOURbejRUyKm0Uu9XVEW7K5nBOZfR8VMB4QR2RQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -6698,7 +6694,8 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -6762,7 +6759,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
       "integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
       "dev": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -7236,7 +7232,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7396,6 +7391,7 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
       "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -7425,6 +7421,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7991,6 +7988,7 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8279,7 +8277,6 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -8657,8 +8654,7 @@
       "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.12.0.tgz",
       "integrity": "sha512-wYKfgdV5suCNx4IVaq0qOjHRxSQ5XOkxfwC8EBHuGCtmEVk8zv1VRg0opV0kVQe89jvRH3iF3Yl/DoB6qiCV5Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",
@@ -8710,7 +8706,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
       "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -9027,7 +9022,6 @@
       "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.39.0.tgz",
       "integrity": "sha512-TWlZ3Z2DlzZzVGM7hZUVxd7P+KCUcrXGVKbaII/5IEQyjiiX34VkJRVGp86k7fRf0vgIKjPcPTHKpoYSthld7g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@bpmn-io/feel-editor": "^2.5.0",
         "@carbon/icons": "^11.69.0",
@@ -9544,6 +9538,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -9553,6 +9548,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
       "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -9562,6 +9558,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
       "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
@@ -9573,6 +9570,7 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
           "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
           "dev": true,
+          "peer": true,
           "requires": {
             "type-detect": "4.0.8"
           }
@@ -9583,7 +9581,8 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@socket.io/component-emitter": {
       "version": "3.1.0",
@@ -9829,8 +9828,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-import-phases": {
       "version": "1.0.4",
@@ -10264,7 +10262,6 @@
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.12.0.tgz",
       "integrity": "sha512-Dg2O+r7jpBwLgWGpManc7P4ZfZQfxTVi2xNtXR3Q2G5Hx1RVYVFoNsQED8+FPCgjy6m7ZQbxKP1sjCJt5rbtBg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "bpmn-moddle": "^10.0.0",
         "diagram-js": "^15.9.0",
@@ -10308,7 +10305,6 @@
       "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.50.1.tgz",
       "integrity": "sha512-XrorbMXf2SQuGIIPQDMTCQU6a5G64ryStU5SFomYdkYWKUvz9Kw+5A2skF5duNjfs48VerLlW9Avq7jOsjJZgg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@bpmn-io/extract-process-variables": "^2.0.0",
         "array-move": "^4.0.0",
@@ -10382,7 +10378,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10439,7 +10434,6 @@
       "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.14.0.tgz",
       "integrity": "sha512-Brbt6ZY+SklZjc77R4WKyBqmLXshcvAJVGIabvQUKqn6IDzClGRlTX/V2aaIC9OyMFuXJRQSd3zYrbZRQHk9vg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "ids": "^3.0.0",
         "min-dash": "^5.0.0"
@@ -10449,8 +10443,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
       "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30001759",
@@ -10462,8 +10455,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -10819,8 +10811,7 @@
       "version": "0.0.1551306",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
       "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "di": {
       "version": "0.0.1",
@@ -10833,7 +10824,6 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.9.0.tgz",
       "integrity": "sha512-9FRoItWkrZnGalrqs0ekwS9wSuHQI2dzO+kJyHKa1hhMJPMBGrjR/cg0XMTpaLo2Vu9/gKL1o19P3sN4/YmIAA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.1",
@@ -10866,7 +10856,8 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "dom-serialize": {
       "version": "2.2.1",
@@ -11154,7 +11145,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12495,7 +12485,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "karma": {
       "version": "6.4.4",
@@ -12674,7 +12665,8 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -13069,7 +13061,6 @@
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.0.0.tgz",
       "integrity": "sha512-ZjE3D0EtU3Qp6ZpxBckGFydIQi++feYvhvxhjNYKGzlC8+2lpcO0lS86WC/B+s2lbAqjrlOMYCQqu6mHAtz2cg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "min-dash": "^5.0.0"
       }
@@ -13125,6 +13116,7 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.7.tgz",
       "integrity": "sha512-wWtNUhkT7k58uvWTB/Gy26eA/EJKtPZFVAhEilN5UYVmmGRYOURbejRUyKm0Uu9XVEW7K5nBOZfR8VMB4QR2RQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -13438,7 +13430,8 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "pend": {
       "version": "1.2.0",
@@ -13480,8 +13473,7 @@
       "version": "10.19.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
       "integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "preact-markup": {
       "version": "2.1.1",
@@ -13815,7 +13807,6 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
           "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -13937,6 +13928,7 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
       "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -13951,6 +13943,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -14355,7 +14348,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "type-fest": {
       "version": "0.20.2",
@@ -14537,7 +14531,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -14802,8 +14795,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.12.0.tgz",
       "integrity": "sha512-wYKfgdV5suCNx4IVaq0qOjHRxSQ5XOkxfwC8EBHuGCtmEVk8zv1VRg0opV0kVQe89jvRH3iF3Yl/DoB6qiCV5Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "zod": {
       "version": "3.25.76",

--- a/test/fixtures/zeebe/mappings/script-task-output-no-name.bpmn
+++ b/test/fixtures/zeebe/mappings/script-task-output-no-name.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qieuld" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:scriptTask id="ScriptTask" name="Script Task">
+      <bpmn:extensionElements>
+        <zeebe:script expression="={&#10;  foo: 123&#10;}" resultVariable="scriptResult" />
+        <zeebe:ioMapping>
+          <zeebe:output source="=scriptResult" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1g8b868_di" bpmnElement="ScriptTask">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/zeebe/Mappings.spec.js
+++ b/test/spec/zeebe/Mappings.spec.js
@@ -17,6 +17,7 @@ import mergingXML from 'test/fixtures/zeebe/mappings/merging.bpmn';
 import scopeXML from 'test/fixtures/zeebe/mappings/scope.bpmn';
 import scriptTaskXML from 'test/fixtures/zeebe/mappings/script-task.bpmn';
 import scriptTaskEmptyExpressionXML from 'test/fixtures/zeebe/mappings/script-task-empty-expression.bpmn';
+import scriptTaskOutputNoNameXML from 'test/fixtures/zeebe/mappings/script-task-output-no-name.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
 
@@ -491,6 +492,34 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
         expect(variables).to.variableEqual([
           {
             name: 'scriptResult'
+          }
+        ]);
+      }));
+    });
+
+
+    describe('output mapping without name', function() {
+
+      beforeEach(bootstrap(scriptTaskOutputNoNameXML));
+
+
+      it('should NOT error for output mapping without a name', inject(async function(variableResolver, elementRegistry) {
+
+        // given
+        const element = elementRegistry.get('ScriptTask');
+
+        // when
+        const variables = await variableResolver.getVariablesForElement(element.businessObject);
+
+        // then
+        expect(variables).to.variableEqual([
+          {
+            name: 'scriptResult',
+            type: 'Context',
+            info: '',
+            entries: [
+              { name: 'foo', type: 'Number', info: '123', entries: [] },
+            ]
           }
         ]);
       }));


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5661

### Proposed Changes

Ensure provided variables from different extractors have a name (to conform to the given variable type). linting will warn about missing names for input and output mappings later

#### Alternatives considered

Just filter in the hierachical expander and adjust name to be `string|undefined` instead of just `string`

### Try out

```
npx @bpmn-io/sr camunda/camunda-bpmn-js -l bpmn-io/variable-resolver#5661_ensure-names-are-given
```

Problematic version for reference
```
npx @bpmn-io/sr camunda/camunda-bpmn-js -l bpmn-io/variable-resolver
```


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
