### PR TITLE
test: verify used variables in different scenarios

### DIFF
--- a/test/fixtures/zeebe/filtering.bpmn
+++ b/test/fixtures/zeebe/filtering.bpmn
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0modwgr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" name="Process_1" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" name="SubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=globalFoo" target="subFoo" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:scriptTask id="Task_1" name="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=&#34;Task_1 :: result&#34; + taskFoo" resultVariable="localResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=subFoo" target="taskFoo" />
+            <zeebe:output source="=localResult" target="taskResult" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:subProcess>
+    <bpmn:textAnnotation id="TextAnnotation_0htuzu9">
+      <bpmn:text>declare: subFoo = globalFoo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0aa1wd0" associationDirection="None" sourceRef="SubProcess_1" targetRef="TextAnnotation_0htuzu9" />
+    <bpmn:textAnnotation id="TextAnnotation_07tfbe4">
+      <bpmn:text>declare: taskFoo = subFoo
+read: taskFoo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_17fzlji" associationDirection="None" sourceRef="Task_1" targetRef="TextAnnotation_07tfbe4" />
+    <bpmn:textAnnotation id="TextAnnotation_0x7whlg">
+      <bpmn:text>write: localResult (-&gt; depending on taskFoo)</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0yn1gyn" associationDirection="None" sourceRef="Task_1" targetRef="TextAnnotation_0x7whlg" />
+    <bpmn:textAnnotation id="TextAnnotation_0cxitau">
+      <bpmn:text>produce: taskResult = localResult</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_14e87h9" associationDirection="None" sourceRef="Task_1" targetRef="TextAnnotation_0cxitau" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0zpajl6_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="290" y="180" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ie6k5k_di" bpmnElement="Task_1">
+        <dc:Bounds x="360" y="240" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0aa1wd0_di" bpmnElement="Association_0aa1wd0">
+        <di:waypoint x="303" y="180" />
+        <di:waypoint x="250" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_14e87h9_di" bpmnElement="Association_14e87h9">
+        <di:waypoint x="451" y="320" />
+        <di:waypoint x="565" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_17fzlji_di" bpmnElement="Association_17fzlji">
+        <di:waypoint x="375" y="320" />
+        <di:waypoint x="283" y="424" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0yn1gyn_di" bpmnElement="Association_0yn1gyn">
+        <di:waypoint x="404" y="320" />
+        <di:waypoint x="382" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0htuzu9_di" bpmnElement="TextAnnotation_0htuzu9">
+        <dc:Bounds x="190" y="70" width="180" height="29.999998092651367" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0cxitau_di" bpmnElement="TextAnnotation_0cxitau">
+        <dc:Bounds x="530" y="430" width="200" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_07tfbe4_di" bpmnElement="TextAnnotation_07tfbe4">
+        <dc:Bounds x="150" y="424" width="170" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0x7whlg_di" bpmnElement="TextAnnotation_0x7whlg">
+        <dc:Bounds x="330" y="480" width="209.99998474121094" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/read-write.bpmn
+++ b/test/fixtures/zeebe/read-write.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kvhh4n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" name="Write: approved" isExecutable="true">
+    <bpmn:serviceTask id="ValidateApprovedTask" name="Validate Approved">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=approved" target="localApproved" />
+          <zeebe:output source="=localApproved" target="approved" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:textAnnotation id="TextAnnotation_12joy1t">
+      <bpmn:text>Write: approved</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1x9i5o6" associationDirection="None" sourceRef="ValidateApprovedTask" targetRef="TextAnnotation_12joy1t" />
+    <bpmn:textAnnotation id="TextAnnotation_0cyrq9q">
+      <bpmn:text>Read: approved</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1qg1o3f" associationDirection="None" sourceRef="TextAnnotation_0cyrq9q" targetRef="ValidateApprovedTask" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_13wsimk_di" bpmnElement="ValidateApprovedTask">
+        <dc:Bounds x="240" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1x9i5o6_di" bpmnElement="Association_1x9i5o6">
+        <di:waypoint x="328" y="170" />
+        <di:waypoint x="386" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1qg1o3f_di" bpmnElement="Association_1qg1o3f">
+        <di:waypoint x="201" y="110" />
+        <di:waypoint x="244" y="172" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_12joy1t_di" bpmnElement="TextAnnotation_12joy1t">
+        <dc:Bounds x="350" y="80" width="120" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1n8m9kv" bpmnElement="TextAnnotation_0cyrq9q">
+        <dc:Bounds x="160" y="80" width="130" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/read-write.hierarchical.bpmn
+++ b/test/fixtures/zeebe/read-write.hierarchical.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kvhh4n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ValidateApprovedTask" name="Validate Approved">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=application.approved" target="localApproved" />
+          <zeebe:output source="=localApproved" target="application.approved" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:textAnnotation id="TextAnnotation_12joy1t">
+      <bpmn:text>Write: application.approved</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1x9i5o6" associationDirection="None" sourceRef="ValidateApprovedTask" targetRef="TextAnnotation_12joy1t" />
+    <bpmn:textAnnotation id="TextAnnotation_0cyrq9q">
+      <bpmn:text>Read: application.approved</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1qg1o3f" associationDirection="None" sourceRef="TextAnnotation_0cyrq9q" targetRef="ValidateApprovedTask" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_13wsimk_di" bpmnElement="ValidateApprovedTask">
+        <dc:Bounds x="290" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1qg1o3f_di" bpmnElement="Association_1qg1o3f">
+        <di:waypoint x="249" y="106" />
+        <di:waypoint x="294" y="172" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1x9i5o6_di" bpmnElement="Association_1x9i5o6">
+        <di:waypoint x="378" y="170" />
+        <di:waypoint x="436" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_12joy1t_di" bpmnElement="TextAnnotation_12joy1t">
+        <dc:Bounds x="400" y="80" width="170" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1n8m9kv" bpmnElement="TextAnnotation_0cyrq9q">
+        <dc:Bounds x="160" y="80" width="170" height="25.999998092651367" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/used-variables.bpmn
+++ b/test/fixtures/zeebe/used-variables.bpmn
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19hmm0v" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="StartEvent_1" targetRef="TriggerCheckTask" />
+    <bpmn:startEvent id="StartEvent_1" name="New subscription request">
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_06kuoon" messageRef="SUBSCRIPTION_REQUEST_MESSAGE" />
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="TriggerCheckTask" name="Trigger check">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1" name="Is age verified" default="SequenceFlow_4">
+      <bpmn:incoming>SequenceFlow_3</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_4</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_3" sourceRef="TriggerCheckTask" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_1" name="Yes" sourceRef="Gateway_1" targetRef="Gateway_2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isAgeVerified</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_4" sourceRef="Gateway_1" targetRef="VerifyAgeTask" />
+    <bpmn:receiveTask id="VerifyAgeTask" name="Verify Age" messageRef="AGE_VERIFIED_MESSAGE">
+      <bpmn:incoming>SequenceFlow_4</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_5</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:exclusiveGateway id="Gateway_2">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_5</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_6</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_6" sourceRef="Gateway_2" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="SequenceFlow_5" sourceRef="VerifyAgeTask" targetRef="Gateway_2" />
+    <bpmn:exclusiveGateway id="Gateway_3" name="Can create subscription?" default="SequenceFlow_7">
+      <bpmn:incoming>SequenceFlow_6</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_10</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_10" name="Yes" sourceRef="Gateway_1" targetRef="CreateSubscriptionTask">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isAgeVerified and is empty(checkResults)</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_7" sourceRef="Gateway_1" targetRef="Send_Rejection" />
+    <bpmn:serviceTask id="CreateSubscriptionTask" name="Create Subscription">
+      <bpmn:incoming>SequenceFlow_10</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_9</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_2" name="Subscription created">
+      <bpmn:incoming>SequenceFlow_9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_9" sourceRef="CreateSubscriptionTask" targetRef="EndEvent_2" />
+    <bpmn:serviceTask id="Send_Rejection" name="Send Rejection">
+      <bpmn:incoming>SequenceFlow_7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_8</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="Rejected">
+      <bpmn:incoming>SequenceFlow_8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_8" sourceRef="Send_Rejection" targetRef="EndEvent_1" />
+    <bpmn:textAnnotation id="TextAnnotation_1id10go">
+      <bpmn:text>This process models a typical pro-code scenario where the data model is implicit ("in code")
+
+* variables are only used, never written in the model
+* intelligence should indicate variables used</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmn:message id="SUBSCRIPTION_REQUEST_MESSAGE" name="SUBSCRIPTION_REQUEST_MESSAGE" />
+  <bpmn:message id="AGE_VERIFIED_MESSAGE" name="AGE_VERIFIED">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=subscriptionRequestID" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_0g6g003_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="345" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TriggerCheckTask_di" bpmnElement="TriggerCheckTask">
+        <dc:Bounds x="270" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="425" y="295" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="416" y="265" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="VerifyAgeTask_di" bpmnElement="VerifyAgeTask">
+        <dc:Bounds x="500" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_2_di" bpmnElement="Gateway_2" isMarkerVisible="true">
+        <dc:Bounds x="655" y="295" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_3_di" bpmnElement="Gateway_3" isMarkerVisible="true">
+        <dc:Bounds x="755" y="295" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="747" y="258" width="65" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CreateSubscriptionTask_di" bpmnElement="CreateSubscriptionTask">
+        <dc:Bounds x="870" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Send_Rejection_di" bpmnElement="Send_Rejection">
+        <dc:Bounds x="870" y="390" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_2_di" bpmnElement="EndEvent_2">
+        <dc:Bounds x="1032" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1020" y="345" width="61" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1032" y="412" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1028" y="455" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="218" y="320" />
+        <di:waypoint x="270" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_3_di" bpmnElement="SequenceFlow_3">
+        <di:waypoint x="370" y="320" />
+        <di:waypoint x="425" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="475" y="320" />
+        <di:waypoint x="655" y="320" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="493" y="293" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_4_di" bpmnElement="SequenceFlow_4">
+        <di:waypoint x="450" y="345" />
+        <di:waypoint x="450" y="430" />
+        <di:waypoint x="500" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_6_di" bpmnElement="SequenceFlow_6">
+        <di:waypoint x="705" y="320" />
+        <di:waypoint x="755" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_5_di" bpmnElement="SequenceFlow_5">
+        <di:waypoint x="600" y="430" />
+        <di:waypoint x="680" y="430" />
+        <di:waypoint x="680" y="345" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10_di" bpmnElement="SequenceFlow_10">
+        <di:waypoint x="805" y="320" />
+        <di:waypoint x="870" y="320" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="829" y="302" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_7_di" bpmnElement="SequenceFlow_7">
+        <di:waypoint x="780" y="345" />
+        <di:waypoint x="780" y="430" />
+        <di:waypoint x="870" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_9_di" bpmnElement="SequenceFlow_9">
+        <di:waypoint x="970" y="320" />
+        <di:waypoint x="1032" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_8_di" bpmnElement="SequenceFlow_8">
+        <di:waypoint x="970" y="430" />
+        <di:waypoint x="1032" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_1id10go_di" bpmnElement="TextAnnotation_1id10go" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="350" y="80" width="375" height="84" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/used-variables.scopes.bpmn
+++ b/test/fixtures/zeebe/used-variables.scopes.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kvhh4n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" name="Process_1" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" name="SubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input target="approved" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_03u12aa</bpmn:outgoing>
+      <bpmn:scriptTask id="Task_2" name="Task_2">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=if approved then 1 else 0" resultVariable="taskResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_03u12aa" sourceRef="SubProcess_1" targetRef="Task_1" />
+    <bpmn:scriptTask id="Task_1" name="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=if approved then &#34;APPROVED&#34; else &#34;NOT APPROVED&#34;" resultVariable="taskResult" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_03u12aa</bpmn:incoming>
+    </bpmn:scriptTask>
+    <bpmn:textAnnotation id="TextAnnotation_06v37so">
+      <bpmn:text>Defines &lt;approved&gt; as local variable</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1vyzo9d" associationDirection="None" sourceRef="SubProcess_1" targetRef="TextAnnotation_06v37so" />
+    <bpmn:textAnnotation id="TextAnnotation_1gqpt1k">
+      <bpmn:text>Uses &lt;approved&gt; variable</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1613yyk" associationDirection="None" sourceRef="TextAnnotation_1gqpt1k" targetRef="Task_1" />
+    <bpmn:association id="Association_15s62zn" associationDirection="None" sourceRef="TextAnnotation_1gqpt1k" targetRef="Task_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0rpc80a_di" bpmnElement="Task_1">
+        <dc:Bounds x="570" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13kwa1s_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="160" y="210" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0azqo33_di" bpmnElement="Task_2">
+        <dc:Bounds x="220" y="270" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1613yyk_di" bpmnElement="Association_1613yyk">
+        <di:waypoint x="480" y="530" />
+        <di:waypoint x="613" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1vyzo9d_di" bpmnElement="Association_1vyzo9d">
+        <di:waypoint x="347" y="210" />
+        <di:waypoint x="355" y="135" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_15s62zn_di" bpmnElement="Association_15s62zn">
+        <di:waypoint x="436" y="530" />
+        <di:waypoint x="279" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_06v37so_di" bpmnElement="TextAnnotation_06v37so">
+        <dc:Bounds x="310" y="80" width="100" height="54.999996185302734" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0u3y3b2" bpmnElement="TextAnnotation_1gqpt1k">
+        <dc:Bounds x="410" y="530" width="110" height="50" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_03u12aa_di" bpmnElement="Flow_03u12aa">
+        <di:waypoint x="510" y="310" />
+        <di:waypoint x="570" y="310" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -35,6 +35,7 @@ import usedVariablesXML from 'test/fixtures/zeebe/used-variables.bpmn';
 import usedVariablesScopesXML from 'test/fixtures/zeebe/used-variables.scopes.bpmn';
 import readWriteXML from 'test/fixtures/zeebe/read-write.bpmn';
 import readWriteHierarchicalXML from 'test/fixtures/zeebe/read-write.hierarchical.bpmn';
+import filteringXML from 'test/fixtures/zeebe/filtering.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
 import { getInputOutput } from '../../../lib/base/util/ExtensionElementsUtil';
@@ -2789,6 +2790,136 @@ describe('ZeebeVariableResolver', function() {
       expect(variables).to.variableEqual([
         { name: 'application', scope: 'Process_1', origin: [ 'ValidateApprovedTask' ], usedBy: [ 'ValidateApprovedTask' ] },
         { name: 'localApproved', scope: 'ValidateApprovedTask' }
+      ]);
+    }));
+
+  });
+
+
+  describe('filtering', function() {
+
+    beforeEach(bootstrapModeler(filteringXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+
+    it('should NOT filter', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'globalFoo', scope: undefined, usedBy: [ 'SubProcess_1' ] },
+        { name: 'subFoo', scope: 'SubProcess_1', origin: [ 'SubProcess_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'taskResult', scope: 'Process_1', origin: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter read', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { read: true });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'subFoo', scope: 'SubProcess_1', origin: [ 'SubProcess_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter read / local', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { read: true, local: true });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter read / global', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { read: true, local: false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'subFoo', scope: 'SubProcess_1', origin: [ 'SubProcess_1' ], usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter write', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { written: true });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'taskResult', scope: 'Process_1', origin: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter written / local', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { written: true, local: true });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskFoo', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] },
+        { name: 'localResult', scope: 'Task_1', origin: [ 'Task_1' ], usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+
+    it('should filter written / global', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task, { written: true, local: false });
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskResult', scope: 'Process_1', origin: [ 'Task_1' ] }
       ]);
     }));
 

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -32,6 +32,8 @@ import longBrokenExpressionXML from 'test/fixtures/zeebe/long-broken-expression.
 import immediatelyBrokenExpressionXML from 'test/fixtures/zeebe/immediately-broken-expression.bpmn';
 import typeResolutionXML from 'test/fixtures/zeebe/type-resolution.bpmn';
 import usedVariablesScopesXML from 'test/fixtures/zeebe/used-variables.scopes.bpmn';
+import readWriteXML from 'test/fixtures/zeebe/read-write.bpmn';
+import readWriteHierarchicalXML from 'test/fixtures/zeebe/read-write.hierarchical.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
 import { getInputOutput } from '../../../lib/base/util/ExtensionElementsUtil';
@@ -2644,6 +2646,66 @@ describe('ZeebeVariableResolver', function() {
       expect(variables).to.variableEqual([
         { name: 'taskResult' },
         { name: 'approved', usedBy: [ 'Task_1' ] }
+      ]);
+    }));
+
+  });
+
+
+  describe('used variables - read and written', function() {
+
+    beforeEach(bootstrapModeler(readWriteXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should indicate dual use', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('ValidateApprovedTask');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'approved', scope: 'Process_1', origin: [ 'ValidateApprovedTask' ], usedBy: [ 'ValidateApprovedTask' ] },
+        { name: 'localApproved', scope: 'ValidateApprovedTask' }
+      ]);
+    }));
+
+  });
+
+
+  describe('used variables - read and written / hierarchical', function() {
+
+    beforeEach(bootstrapModeler(readWriteHierarchicalXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should indicate dual use', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('ValidateApprovedTask');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'application', scope: 'Process_1', origin: [ 'ValidateApprovedTask' ], usedBy: [ 'ValidateApprovedTask' ] },
+        { name: 'localApproved', scope: 'ValidateApprovedTask' }
       ]);
     }));
 

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -31,6 +31,7 @@ import subprocessNoOutputMappingXML from 'test/fixtures/zeebe/sub-process.no-out
 import longBrokenExpressionXML from 'test/fixtures/zeebe/long-broken-expression.bpmn';
 import immediatelyBrokenExpressionXML from 'test/fixtures/zeebe/immediately-broken-expression.bpmn';
 import typeResolutionXML from 'test/fixtures/zeebe/type-resolution.bpmn';
+import usedVariablesScopesXML from 'test/fixtures/zeebe/used-variables.scopes.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
 import { getInputOutput } from '../../../lib/base/util/ExtensionElementsUtil';
@@ -2599,6 +2600,52 @@ describe('ZeebeVariableResolver', function() {
       }));
 
     });
+
+  });
+
+
+  describe('used variables - scopes', function() {
+
+    beforeEach(bootstrapModeler(usedVariablesScopesXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should attach <usedBy> to local scope', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const subProcess = elementRegistry.get('SubProcess_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(subProcess);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskResult' },
+        { name: 'approved', usedBy: [ 'Task_2' ] }
+      ]);
+    }));
+
+
+    it('should attach <usedBy> to global scope', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const rootElement = elementRegistry.get('Process_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(rootElement);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'taskResult' },
+        { name: 'approved', usedBy: [ 'Task_1' ] }
+      ]);
+    }));
 
   });
 

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -31,6 +31,7 @@ import subprocessNoOutputMappingXML from 'test/fixtures/zeebe/sub-process.no-out
 import longBrokenExpressionXML from 'test/fixtures/zeebe/long-broken-expression.bpmn';
 import immediatelyBrokenExpressionXML from 'test/fixtures/zeebe/immediately-broken-expression.bpmn';
 import typeResolutionXML from 'test/fixtures/zeebe/type-resolution.bpmn';
+import usedVariablesXML from 'test/fixtures/zeebe/used-variables.bpmn';
 import usedVariablesScopesXML from 'test/fixtures/zeebe/used-variables.scopes.bpmn';
 import readWriteXML from 'test/fixtures/zeebe/read-write.bpmn';
 import readWriteHierarchicalXML from 'test/fixtures/zeebe/read-write.hierarchical.bpmn';
@@ -2648,6 +2649,88 @@ describe('ZeebeVariableResolver', function() {
         { name: 'approved', usedBy: [ 'Task_1' ] }
       ]);
     }));
+
+  });
+
+
+  describe('used variables - pro code', function() {
+
+    beforeEach(bootstrapModeler(usedVariablesXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should expose used variables globally', inject(async function(elementRegistry, variableResolver) {
+
+      // when
+      const allVariables = await variableResolver.getVariables();
+
+      // then
+      expect(allVariables).to.have.property('Process_1');
+
+      expect(allVariables['Process_1']).to.variableEqual([
+        { name: 'isAgeVerified', usedBy: [ 'SequenceFlow_1', 'SequenceFlow_10' ], scope: undefined, origin: undefined },
+        { name: 'subscriptionRequestID', usedBy: [ 'VerifyAgeTask' ], scope: undefined, origin: undefined },
+        { name: 'checkResults', usedBy: [ 'SequenceFlow_10' ], scope: undefined, origin: undefined }
+      ]);
+
+      // and when
+      const rootElement = elementRegistry.get('Process_1');
+
+      const processVariables = await variableResolver.getProcessVariables(rootElement);
+
+      expect(processVariables).to.eql(allVariables['Process_1']);
+    }));
+
+
+    describe('should expose used variables per element', function() {
+
+      it('sequence flow', inject(async function(elementRegistry, variableResolver) {
+
+        // when
+        const flow = elementRegistry.get('SequenceFlow_1');
+
+        const variables = await variableResolver.getVariablesForElement(flow);
+
+        // then
+        expect(variables).to.variableEqual([
+          { name: 'isAgeVerified', usedBy: [ 'SequenceFlow_1', 'SequenceFlow_10' ], scope: undefined, origin: undefined }
+        ]);
+      }));
+
+
+      it('receive task', inject(async function(elementRegistry, variableResolver) {
+
+        // when
+        const task = elementRegistry.get('VerifyAgeTask');
+
+        const variables = await variableResolver.getVariablesForElement(task);
+
+        // then
+        expect(variables).to.variableEqual([
+          { name: 'subscriptionRequestID', usedBy: [ 'VerifyAgeTask' ], scope: undefined, origin: undefined }
+        ]);
+      }));
+
+
+      it('process', inject(async function(elementRegistry, variableResolver) {
+
+        // when
+        const rootElement = elementRegistry.get('Process_1');
+
+        const variables = await variableResolver.getVariablesForElement(rootElement);
+
+        // then
+        // TODO(nikku): should that include variables not used by process?
+        expect(variables).to.variableEqual([]);
+      }));
+
+    });
 
   });
 


### PR DESCRIPTION
### Proposed Changes

Validate scenarios for used variables, discussed [here](https://docs.google.com/document/d/1W8o4MuEEQ9dO8A7JtIcehIP9x4-tAl9JuMhlpZAj4t4/edit?tab=t.0).

#### Scenario 1: Pro-code setup

This adds test cases for used variables - in the extreme case where no variables are produced ("pro-code"):

<img width="1289" height="612" alt="image" src="https://github.com/user-attachments/assets/30b12edb-15c7-414c-91e1-6dac358b60a0" />


#### Scenario 2: Variable written and read (https://github.com/bpmn-io/variable-resolver/pull/91)

Validate representation of variable that is read and written by a task:

<img width="604" height="365" alt="image" src="https://github.com/user-attachments/assets/3a1423db-b084-48b5-abef-8e264c386319" />

<img width="639" height="405" alt="image" src="https://github.com/user-attachments/assets/14885bcc-bea9-4df6-b4b5-79457632ea25" />


#### Scenario 3: Variable attaches to correct scope (https://github.com/bpmn-io/variable-resolver/pull/92)

Verify that `usedBy` meta-data is attached to relevant scope:

<img width="820" height="763" alt="image" src="https://github.com/user-attachments/assets/19cb3613-ecdf-4381-99a6-ddc4be9763c7" />


#### Scenario 4: Proposed filtering mechanism (https://github.com/bpmn-io/variable-resolver/pull/93)

Verify the newly proposed filtering mechanism works:

<img width="821" height="673" alt="image" src="https://github.com/user-attachments/assets/2839e97b-6ed9-49f4-a77e-2fc14e7432ab" />

From the documentation:

```
// variables available in scope of <task>
await variableResolver.getVariablesForElement(task);

// variables read by <task>, excluding local ones
await variableResolver.getVariablesForElement(task, { read: true, local: false });

// all variables written by <task>
await variableResolver.getVariablesForElement(task, { written: true });
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
