### PR TITLE
fix: show FEEL expression for unresolvable function invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@bpmn-io/variable-resolver](https://github.com/bpmn-io/v
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: show FEEL expression for unresolvable function invocations ([#104](https://github.com/bpmn-io/variable-resolver/pull/104), [camunda/camunda-modeler#5744](https://github.com/camunda/camunda-modeler/issues/5744))
+
 ## 3.0.0
 
 * `FEAT`: expose both read and written variables. `getVariablesForElement` can be used to retrieve variables for a specific element ([#74](https://github.com/bpmn-io/variable-resolver/pull/74))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [@bpmn-io/variable-resolver](https://github.com/bpmn-io/v
 ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: show FEEL expression for unresolvable function invocations ([#104](https://github.com/bpmn-io/variable-resolver/pull/104), [camunda/camunda-modeler#5744](https://github.com/camunda/camunda-modeler/issues/5744))
+* `DEPS`: update to `@bpmn-io/lezer-feel@2.4.0`
 
 ## 3.0.0
 

--- a/lib/zeebe/util/feelUtility.js
+++ b/lib/zeebe/util/feelUtility.js
@@ -314,6 +314,14 @@ function resolveReferences(variablesToResolve, allVariables) {
       computedResult.value.info = expression;
     }
 
+    // If the result is still unresolvable (type "Any") and no info was set,
+    // preserve the original FEEL expression as info so users can see the
+    // expression itself (e.g. "=abs(-22)") instead of a blank value.
+    // cf. https://github.com/camunda/camunda-modeler/issues/5744
+    if (getType(computedResult.value) === 'Any' && !computedResult.value.info) {
+      computedResult.value.info = expression;
+    }
+
     // Ensure we don't copy the scope from the mapped variable
     computedResult.scope = variable.scope;
 
@@ -656,9 +664,25 @@ export function toUnifiedFormat(variables) {
       continue;
     }
 
+    const annotated = annotate(variable);
+    const entries = toUnifiedFormat(variable.entries);
+
+    if (isNullishValue(annotated, entries)) {
+
+      // FEEL has no "unknown" concept. So we normalize to Null.
+      result.push({
+        name: key,
+        type: 'Null',
+        info: 'null',
+        scope: variable.scope
+      });
+
+      continue;
+    }
+
     result.push({
-      ...annotate(variable),
-      entries: toUnifiedFormat(variable.entries),
+      ...annotated,
+      entries,
       name: key,
       scope: variable.scope
     });
@@ -667,6 +691,16 @@ export function toUnifiedFormat(variables) {
   return result;
 }
 
+
+/**
+ * Values with unknown type, no info, and no sub-entries cannot be
+ * determined at design time (e.g. nested results of unresolvable
+ * function invocations).
+ */
+function isNullishValue(annotated, entries) {
+  return annotated.type === 'Any' && !annotated.info &&
+    (!entries || !entries.length);
+}
 
 function annotate(variable) {
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^2.2.1",
         "@bpmn-io/feel-analyzer": "^0.1.0",
-        "@bpmn-io/lezer-feel": "^2.3.1",
+        "@bpmn-io/lezer-feel": "^2.4.0",
         "@camunda/feel-builtins": "^1.0.0",
         "@lezer/common": "^1.5.1",
         "min-dash": "^5.0.0"
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@bpmn-io/lezer-feel": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.3.1.tgz",
-      "integrity": "sha512-MNe3M7XUuUk0OvrIIXM0m7M2hNLouxPqJyqd6+XCDMy9dsan0zLA0vl7Cu8ypCbsAlViIGIvYdkjzZNiXd3gng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.4.0.tgz",
+      "integrity": "sha512-V6L6p7GZSQnpNld1RKlk9A2GYmKoK3f1Qnzcay58ei/OGYDUHCl+267ldhe9LRmlFUr5emp5MSvjG2ekkXdwtQ==",
       "license": "MIT",
       "dependencies": {
         "@lezer/highlight": "^1.2.3",
@@ -9020,9 +9020,9 @@
       }
     },
     "@bpmn-io/lezer-feel": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.3.1.tgz",
-      "integrity": "sha512-MNe3M7XUuUk0OvrIIXM0m7M2hNLouxPqJyqd6+XCDMy9dsan0zLA0vl7Cu8ypCbsAlViIGIvYdkjzZNiXd3gng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.4.0.tgz",
+      "integrity": "sha512-V6L6p7GZSQnpNld1RKlk9A2GYmKoK3f1Qnzcay58ei/OGYDUHCl+267ldhe9LRmlFUr5emp5MSvjG2ekkXdwtQ==",
       "requires": {
         "@lezer/highlight": "^1.2.3",
         "@lezer/lr": "^1.4.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@bpmn-io/extract-process-variables": "^2.2.1",
     "@bpmn-io/feel-analyzer": "^0.1.0",
-    "@bpmn-io/lezer-feel": "^2.3.1",
+    "@bpmn-io/lezer-feel": "^2.4.0",
     "@camunda/feel-builtins": "^1.0.0",
     "@lezer/common": "^1.5.1",
     "min-dash": "^5.0.0"

--- a/test/fixtures/zeebe/function-invocation.bpmn
+++ b/test/fixtures/zeebe/function-invocation.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="Process_functionInvocation" isExecutable="true">
+    <bpmn:serviceTask id="functionInvocationTask" name="Function Invocation">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=abs(-22)" target="outAbs" />
+          <zeebe:output source="=substring(&#34;foobar&#34;, 3)" target="outSubstring" />
+          <zeebe:output source="=now()" target="outNow" />
+          <zeebe:output source="={ a: function() { nested: abs(x) }, b: a() }.b" target="outContextFunc" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_functionInvocation">
+      <bpmndi:BPMNShape id="functionInvocationTask_di" bpmnElement="functionInvocationTask">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -32,6 +32,7 @@ import subprocessNoOutputMappingXML from 'test/fixtures/zeebe/sub-process.no-out
 import longBrokenExpressionXML from 'test/fixtures/zeebe/long-broken-expression.bpmn';
 import immediatelyBrokenExpressionXML from 'test/fixtures/zeebe/immediately-broken-expression.bpmn';
 import typeResolutionXML from 'test/fixtures/zeebe/type-resolution.bpmn';
+import functionInvocationXML from 'test/fixtures/zeebe/function-invocation.bpmn';
 import usedVariablesXML from 'test/fixtures/zeebe/used-variables.bpmn';
 import usedVariablesScopesXML from 'test/fixtures/zeebe/used-variables.scopes.bpmn';
 import readWriteXML from 'test/fixtures/zeebe/read-write.bpmn';
@@ -2664,6 +2665,75 @@ describe('ZeebeVariableResolver', function() {
       }));
 
     });
+
+  });
+
+
+  describe('function invocation resolution', function() {
+
+    beforeEach(bootstrapModeler(functionInvocationXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+    it('should show expression for unresolvable function calls', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('functionInvocationTask');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableInclude([
+        {
+          name: 'outAbs',
+          type: 'Any',
+          info: '=abs(-22)',
+          scope: 'Process_functionInvocation'
+        },
+        {
+          name: 'outSubstring',
+          type: 'Any',
+          info: '=substring("foobar", 3)',
+          scope: 'Process_functionInvocation'
+        },
+        {
+          name: 'outNow',
+          type: 'Any',
+          info: '=now()',
+          scope: 'Process_functionInvocation'
+        }
+      ]);
+    }));
+
+
+    it('should preserve nested entries in context-defined function results', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const task = elementRegistry.get('functionInvocationTask');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableInclude({
+        name: 'outContextFunc',
+        type: 'Context',
+        scope: 'Process_functionInvocation',
+        entries: [
+          {
+            name: 'nested',
+            type: 'Null',
+            info: 'null'
+          }
+        ]
+      });
+    }));
 
   });
 


### PR DESCRIPTION
Related to camunda/camunda-modeler#5744

### Proposed Changes

This pull request aims to preserve the FEEL expression for the built-in functions for downstream to display them on the user-interface. This pull request is enabled by [lezer-feel changes](https://github.com/nikku/lezer-feel/pull/84).


**Before**

<img width="1107" height="988" alt="image" src="https://github.com/user-attachments/assets/c2e5145e-b48f-47ac-809a-b29daec2c99a" />
<br>

**After**

<img width="938" height="1004" alt="image" src="https://github.com/user-attachments/assets/8eaaa319-6d56-45e9-a1fa-eb556b4a24aa" />
<br>


**Tests**

The tests can be observed in https://github.com/bpmn-io/variable-resolver/pull/105 with the necessary changes from the [lezer-feel pull request](https://github.com/nikku/lezer-feel/pull/84).

**Steps to try out**

This is the command I'd have suggested to experiment with variable over variable-outline, but I had no luck having it run so far. I think it's failing because linked dependencies are not direct dependencies of `variable-outline` and they're not declared as `overrides` by `@bpmn-io/sr`.

`npx @bpmn-io/sr bpmn-io/variable-outline -l bpmn-io/variable-resolver#issue-5744-show-expression-for-unresolvable-values -l bpmn-io/lezer-feel#issue-5744-fix-function-invocation-value`

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
