### PR TITLE
fix: reconcile flow element consumed variables with scoped declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@bpmn-io/variable-resolver](https://github.com/bpmn-io/v
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: reconcile flow element consumed variables with scoped declarations ([#110](https://github.com/bpmn-io/variable-resolver/pull/110))
+
 ## 3.0.1
 
 * `DEPS`: update to `@bpmn-io/lezer-feel@2.3.2` ([#106](https://github.com/bpmn-io/variable-resolver/pull/106))

--- a/lib/zeebe/VariableResolver.js
+++ b/lib/zeebe/VariableResolver.js
@@ -127,17 +127,17 @@ export default class ZeebeVariableResolver extends BaseVariableResolver {
 
     for (const key in rawVariables) {
       const variables = rawVariables[key];
-      const { resolvedVariables, consumedVariables } = parseVariables(variables);
       const rootElement = getRootElementById(definitions, key);
-      const elementConsumedVariables = rootElement
+      const consumedVariablesByFlowElements = rootElement
         ? extractConsumedVariablesFromElements(getFlowElements(rootElement))
         : [];
+
+      const { resolvedVariables, consumedVariables } = parseVariables(variables, consumedVariablesByFlowElements);
 
       mappedVariables[key] = [
         ...variables,
         ...resolvedVariables,
-        ...consumedVariables,
-        ...elementConsumedVariables
+        ...consumedVariables
       ];
     }
 

--- a/lib/zeebe/util/feelUtility.js
+++ b/lib/zeebe/util/feelUtility.js
@@ -30,9 +30,10 @@ const feelAnalyzer = new FeelAnalyzer({
  * Consumption analysis inspects all relevant non-output expressions.
  *
  * @param {Array<ProcessVariable>} variables
+ * @param {Array<ProcessVariable>} [consumedVariablesByFlowElements]
  * @returns {{ resolvedVariables: Array<ProcessVariable>, consumedVariables: Array<ProcessVariable> }}
  */
-export function parseVariables(variables) {
+export function parseVariables(variables, consumedVariablesByFlowElements = []) {
   const variablesToResolve = [];
   const analysisResults = [];
 
@@ -110,9 +111,14 @@ export function parseVariables(variables) {
   }
 
   // Step 5 - Bridge consumed usages back to uniquely scoped declarations
-  annotateConsumedUsagesToScopedVariables(variables, consumedVariables);
+  const allConsumedVariables = [ ...consumedVariables, ...consumedVariablesByFlowElements ];
+  annotateConsumedUsagesToScopedVariables(variables, allConsumedVariables);
 
-  return { resolvedVariables, consumedVariables };
+  const scopelessConsumedByFlowElements = consumedVariablesByFlowElements.filter(
+    v => !variables.some(sv => sv.name === v.name && sv.scope)
+  );
+
+  return { resolvedVariables, consumedVariables: [ ...consumedVariables, ...scopelessConsumedByFlowElements ] };
 }
 
 function annotateConsumedUsagesToScopedVariables(variables, consumedVariables) {

--- a/test/fixtures/zeebe/read-write.flow-element.bpmn
+++ b/test/fixtures/zeebe/read-write.flow-element.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.47.0-rc.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="ReviewTask" name="Review">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=&#34;approved&#34;" target="reviewOutcome" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_Approved</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Rejected</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="EndEvent_Approved">
+      <bpmn:incoming>Flow_Approved</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_Rejected">
+      <bpmn:incoming>Flow_Rejected</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ReviewTask" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="ReviewTask" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="Flow_Approved" sourceRef="Gateway_1" targetRef="EndEvent_Approved">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=reviewOutcome = "approved"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Rejected" sourceRef="Gateway_1" targetRef="EndEvent_Rejected">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=reviewOutcome = "rejected"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReviewTask_di" bpmnElement="ReviewTask">
+        <dc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="395" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Approved_di" bpmnElement="EndEvent_Approved">
+        <dc:Bounds x="502" y="42" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Rejected_di" bpmnElement="EndEvent_Rejected">
+        <dc:Bounds x="502" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="395" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Approved_di" bpmnElement="Flow_Approved">
+        <di:waypoint x="420" y="95" />
+        <di:waypoint x="420" y="60" />
+        <di:waypoint x="502" y="60" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Rejected_di" bpmnElement="Flow_Rejected">
+        <di:waypoint x="420" y="145" />
+        <di:waypoint x="420" y="170" />
+        <di:waypoint x="502" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -36,6 +36,7 @@ import usedVariablesXML from 'test/fixtures/zeebe/used-variables.bpmn';
 import usedVariablesScopesXML from 'test/fixtures/zeebe/used-variables.scopes.bpmn';
 import readWriteXML from 'test/fixtures/zeebe/read-write.bpmn';
 import readWriteHierarchicalXML from 'test/fixtures/zeebe/read-write.hierarchical.bpmn';
+import readWriteFlowElementXML from 'test/fixtures/zeebe/read-write.flow-element.bpmn';
 import filteringXML from 'test/fixtures/zeebe/filtering.bpmn';
 
 import VariableProvider from 'lib/VariableProvider';
@@ -2873,6 +2874,32 @@ describe('ZeebeVariableResolver', function() {
       expect(variables).to.variableEqual([
         { name: 'application', scope: 'Process_1', origin: [ 'ValidateApprovedTask' ], usedBy: [ 'ValidateApprovedTask' ] },
         { name: 'localApproved', scope: 'ValidateApprovedTask' }
+      ]);
+    }));
+
+  });
+
+
+  describe('used variables - read and written / flow element', function() {
+
+    beforeEach(bootstrapModeler(readWriteFlowElementXML, {
+      additionalModules: [
+        ZeebeVariableResolverModule
+      ],
+      moddleExtensions: {
+        zeebe: ZeebeModdle
+      }
+    }));
+
+
+    it('should reconcile consumed variable from sequence flow with scoped declaration', inject(async function(elementRegistry, variableResolver) {
+
+      // when
+      const allVariables = await variableResolver.getVariables();
+
+      // then
+      expect(allVariables['Process_1']).to.variableEqual([
+        { name: 'reviewOutcome', scope: 'Process_1', origin: [ 'ReviewTask' ], usedBy: [ 'Flow_Approved', 'Flow_Rejected' ] }
       ]);
     }));
 


### PR DESCRIPTION
Closes #109

### Proposed Changes

This pull request aims to reconcile consumed variables extracted out of flow elements. Before these changes, variable-resolver was returning an extra consumed variable due to the consumption from the flow elements even though the variable was actually declared in the diagram.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x ] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
