### PR TITLE
fix: add graceful handling for unparsable result expressions

### DIFF
--- a/lib/zeebe/extractors/connectors.js
+++ b/lib/zeebe/extractors/connectors.js
@@ -41,7 +41,7 @@ class ConnectorVariableProvider extends VariableProvider {
 
       const expressionVariables = toUnifiedFormat(resultContext.computedValue());
 
-      if (expressionVariables && expressionVariables.length > 0) {
+      if (Array.isArray(expressionVariables?.[0]?.entries)) {
         result.push(
           ...expressionVariables[0].entries
         );

--- a/test/fixtures/zeebe/connectors.bpmn
+++ b/test/fixtures/zeebe/connectors.bpmn
@@ -7,6 +7,7 @@
     <bpmn:participant id="Participant_0x41u3u" processRef="Process_096t6a2" />
     <bpmn:participant id="Participant_0sod0ky" processRef="Process_0ierhlh" />
     <bpmn:participant id="Participant_3" name="Participant_3" processRef="Process_6" />
+    <bpmn:participant id="Participant_unparsable" processRef="Process_unparsable" />
     <bpmn:textAnnotation id="TextAnnotation_1">
       <bpmn:text>Use pools to easily encapsulate the variable scope during testing</bpmn:text>
     </bpmn:textAnnotation>
@@ -58,6 +59,16 @@
       <bpmn:extensionElements>
         <zeebe:taskHeaders>
           <zeebe:header key="resultExpression" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:process id="Process_unparsable" isExecutable="false">
+    <bpmn:serviceTask id="unparsableExpressionTask" name="unparsable expression" zeebe:modelerTemplate="io.camunda.connectors.testMappings.v1">
+      <bpmn:extensionElements>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="resultVariable" />
+          <zeebe:header key="resultExpression" value="={&#10;  test: ttt&#10;  myResponseBody: response.body&#10;}" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>
     </bpmn:serviceTask>
@@ -139,6 +150,13 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
         <dc:Bounds x="430" y="80" width="155" height="55" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_unparsable_di" bpmnElement="Participant_unparsable" isHorizontal="true">
+        <dc:Bounds x="170" y="760" width="300" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="unparsableExpressionTask_di" bpmnElement="unparsableExpressionTask">
+        <dc:Bounds x="270" y="780" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -1269,6 +1269,22 @@ describe('ZeebeVariableResolver', function() {
 
     }));
 
+
+    it('should not throw on unparsable resultExpression and still return resultVariable', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('unparsableExpressionTask');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'resultVariable', origin: [ 'unparsableExpressionTask' ] },
+      ]);
+
+    }));
+
   });
 
 


### PR DESCRIPTION
Closes #113

### Proposed Changes

Variable extraction crashes while trying to extract variables from a result expression consisting of an unparsable FEEL expression. This results in no variables being provided out of `variable-resolver` rather than still providing the extractable ones.

In the provided test case, we expect to still extract a variable named in the `resultVariable` property even though `resultExpression` has an unparsable expression in it due to missing comma.

```json
{
  test: ttt
  myResponseBody: response.body
}
```

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
