### PR TITLE
feat: expose per-writer value variants on merged variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [@bpmn-io/variable-resolver](https://github.com/bpmn-io/v
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: expose per-writer value `variants` on merged variables ([#123](https://github.com/bpmn-io/variable-resolver/pull/123))
 * `CHORE`: resolve mapped variables per origin ([#123](https://github.com/bpmn-io/variable-resolver/pull/123))
 
 ## 3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@bpmn-io/variable-resolver](https://github.com/bpmn-io/v
 
 ___Note:__ Yet to be released changes appear here._
 
+* `CHORE`: resolve mapped variables per origin ([#123](https://github.com/bpmn-io/variable-resolver/pull/123))
+
 ## 3.2.0
 
 * `FEAT`: recognize additional Camunda built-ins ([#121](https://github.com/bpmn-io/variable-resolver/pull/121))

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Merged variables additionally expose `variants`, one per writing element. Each v
  * variable = {
  *   name: 'myVariable',
  *   type: 'Number|String',
- *   origin: [ Task_1, Task_2 ],
+ *   origin: [ 'Task_1', 'Task_2' ],
  *   variants: [
- *     { name: 'myVariable', type: 'String', origin: [ Task_1 ], ... },
- *     { name: 'myVariable', type: 'Number', origin: [ Task_2 ], ... }
+ *     { name: 'myVariable', type: 'String', origin: [ 'Task_1' ], ... },
+ *     { name: 'myVariable', type: 'Number', origin: [ 'Task_2' ], ... }
  *   ],
  *   ...
  * }

--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ export const MyExtension = {
 
 By default, `getVariablesForElement` and `getProcessVariables` merge variables with the same name and scope into one - entry structure and types are mixed in the merged representation.
 
+Merged variables additionally expose `variants`, one per writing element. Each variant is shaped like a variable and describes only the value contributed by its single `origin`:
+
+```javascript
+/**
+ * variable = {
+ *   name: 'myVariable',
+ *   type: 'Number|String',
+ *   origin: [ Task_1, Task_2 ],
+ *   variants: [
+ *     { name: 'myVariable', type: 'String', origin: [ Task_1 ], ... },
+ *     { name: 'myVariable', type: 'Number', origin: [ Task_2 ], ... }
+ *   ],
+ *   ...
+ * }
+ */
+```
+
 In some cases, you might want access to the raw data, e.g. to run lint rules to detect potential schema mismatches between providers. For this, you can use `getRawVariables`:
 
 ```javascript

--- a/lib/base/VariableResolver.js
+++ b/lib/base/VariableResolver.js
@@ -20,6 +20,7 @@ import { getParents } from './util/elementsUtil';
  * @property {Array<Object>} provider
  * @property {Array<string|ModdleElement>} [usedBy] Elements or variable names consuming this variable
  * @property {Array<string>} [readFrom] Source tags describing where this variable is read from
+ * @property {Array<ProcessVariable>} [variants] Per-writer value descriptions, each carrying a single origin
  */
 
 /**
@@ -181,8 +182,10 @@ export class BaseVariableResolver {
           const existingVariable = mergedMap.get(mergeKey);
 
           if (existingVariable) {
+            addVariants(existingVariable.variants, variable);
             mergeVariables(existingVariable, variable);
           } else {
+            variable.variants = addVariants([], variable);
             mergedMap.set(mergeKey, variable);
           }
         } else {
@@ -438,6 +441,47 @@ function merge(property, target, source) {
   target[property].push(...propertiesToAdd);
 }
 
+/**
+ * Collect per-writer value variants of a merged variable.
+ *
+ * Each variant is shaped like a variable and describes the value a single
+ * writing element (origin) contributes. The contributed value fields are
+ * cloned so later merges do not leak one writer's value description into
+ * another writer's variant.
+ *
+ * @param {Array<ProcessVariable>} variants
+ * @param {ProcessVariable} variable
+ *
+ * @return {Array<ProcessVariable>} variants
+ */
+function addVariants(variants, variable) {
+  const origins = variable.origin || [];
+
+  for (const origin of origins) {
+    const contribution = {
+      name: variable.name,
+      type: variable.type,
+      info: variable.info,
+      isList: variable.isList,
+      entries: variable.entries && variable.entries.map(cloneVariable),
+      scope: variable.scope
+    };
+
+    const variant = variants.find(v => v.origin[0] === origin);
+
+    if (variant) {
+      mergeEntries(variant, contribution);
+    } else {
+      variants.push({
+        ...contribution,
+        origin: [ origin ]
+      });
+    }
+  }
+
+  return variants;
+}
+
 export function mergeEntries(target, source, visited = []) {
   if (visited.includes(source) || visited.includes(target)) {
     return;
@@ -482,6 +526,10 @@ function mapToEditorFormat(variables) {
 
     if (variable.entries) {
       mapToEditorFormat(variable.entries);
+    }
+
+    if (variable.variants) {
+      mapToEditorFormat(variable.variants);
     }
   });
 }

--- a/lib/zeebe/util/feelUtility.js
+++ b/lib/zeebe/util/feelUtility.js
@@ -58,7 +58,7 @@ export function parseVariables(variables) {
         unresolved
       } = expressionDetails;
 
-      variablesToResolve.push({ variable, expression, unresolved });
+      variablesToResolve.push({ variable, origin, expression, unresolved });
 
       const requirementAnalyses = collectRequirementAnalyses(expressionCandidates, expression, expressionDetails);
 
@@ -226,7 +226,7 @@ function hasUsage(usages, usage) {
  * Variables with expression mappings are evaluated in a best-effort topological
  * order. Variables without mappings are provided as initial context.
  *
- * @param {Array<{ variable: ProcessVariable, expression: string, unresolved: Array<string> }>} variablesToResolve
+ * @param {Array<{ variable: ProcessVariable, origin: djs.model.Base, expression: string, unresolved: Array<string> }>} variablesToResolve
  * @param {Array<ProcessVariable>} allVariables
  * @returns {Array<ProcessVariable>}
  */
@@ -275,7 +275,7 @@ function resolveReferences(variablesToResolve, allVariables) {
 
   // Step 2.2 - parse in order, building up the context with resolved variable values
   // This will resolve all variables that don't have circular dependencies on each other
-  sortedVariables.forEach(({ variable, expression, unresolved }) => {
+  sortedVariables.forEach(({ variable, origin, expression, unresolved }) => {
     const scopedContext = filterForScope(rootContext, variable);
     const resultContext = getResultContext(expression, scopedContext);
 
@@ -317,6 +317,16 @@ function resolveReferences(variablesToResolve, allVariables) {
     // Ensure we don't copy the scope from the mapped variable
     computedResult.scope = variable.scope;
 
+    // Snapshot the resolved value before cross-origin type unions below,
+    // keeping the result specific to the resolved origin
+    newVariables.push({
+      newVariable: toUnifiedFormat({
+        [variable.name]: computedResult
+      })[0],
+      oldVariable: variable,
+      origin
+    });
+
     // If the same variable name was already resolved (e.g. via input mapping AND a task output),
     // merge the types so downstream expressions see the full union (e.g. 'Null|Number').
     const existing = rootContext.entries[variable.name];
@@ -331,21 +341,16 @@ function resolveReferences(variablesToResolve, allVariables) {
     }
 
     rootContext.entries[variable.name] = computedResult;
-
-    newVariables.push({
-      newVariable: toUnifiedFormat({
-        [variable.name]: computedResult
-      })[0],
-      oldVariable: variable
-    });
   });
 
-  // Ensure meta-data (scope, origin) is kept from original variable
-  const enrichedVariables = newVariables.map(({ newVariable, oldVariable }) => {
+  // Ensure meta-data (scope, origin) is kept from original variable,
+  // narrowing the origin to the one the expression was resolved for
+  const enrichedVariables = newVariables.map(({ newVariable, oldVariable, origin }) => {
     if (oldVariable) {
       return {
         ...newVariable,
-        ...oldVariable
+        ...oldVariable,
+        ...origin ? { origin: [ origin ] } : {}
       };
     }
     return newVariable;

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -2,23 +2,32 @@ const { expect } = require('chai');
 const { has } = require('min-dash');
 
 
-function isDefined(value) {
-  return typeof value !== 'undefined';
-}
-
 function findVariable(variables, expectedVariable) {
   const {
     name,
-    scope
+    scope,
+    origin
   } = expectedVariable;
 
   const variable = variables.find(
-    v => (!isDefined(name) || v.name === name) && (!isDefined(scope) || v.scope?.id === scope)
+    v => (!name || v.name === name)
+      && (!scope || v.scope?.id === scope)
+      && (!origin || matchesOrigin(v.origin, origin))
   );
 
   expect(variable, `variable[name=${name}, scope=${scope}]`).to.exist;
 
   return variable;
+}
+
+function matchesOrigin(origin, expectedOrigin) {
+  if (!origin || origin.length !== expectedOrigin.length) {
+    return false;
+  }
+
+  return expectedOrigin.every(
+    expectedId => origin.some(o => o && o.id === expectedId)
+  );
 }
 
 function assertVariableMatches(variable, expectedVariable) {
@@ -69,6 +78,16 @@ function assertVariableMatches(variable, expectedVariable) {
       expect(variable.origin.length, `variable[name=${name}].origin.length`).to.eql(expectedVariable.origin.length);
     } else {
       expect(variable.origin, `variable[name=${name}].origin`).not.to.exist;
+    }
+  }
+
+  if (has(expectedVariable, 'variants')) {
+
+    if (expectedVariable.variants) {
+      expect(variable.variants, `variable[name=${name}].variants`).to.exist;
+      expect(variable.variants, `variable[name=${name}].variants`).to.variableEqual(expectedVariable.variants);
+    } else {
+      expect(variable.variants, `variable[name=${name}].variants`).not.to.exist;
     }
   }
 

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -15,7 +15,7 @@ function findVariable(variables, expectedVariable) {
       && (!origin || matchesOrigin(v.origin, origin))
   );
 
-  expect(variable, `variable[name=${name}, scope=${scope}]`).to.exist;
+  expect(variable, `variable[name=${name}, scope=${scope}, origin=${origin}]`).to.exist;
 
   return variable;
 }

--- a/test/fixtures/zeebe/mappings/merging.per-element.bpmn
+++ b/test/fixtures/zeebe/mappings/merging.per-element.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pere1m" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:process id="Process_LoanApproval" name="Loan approval" isExecutable="true">
+    <bpmn:serviceTask id="Task_ScoreApplicant" name="Score applicant">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="={ score: { value: 720 } }" target="reviewOutcome" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_FlagManualReview" name="Flag manual review">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=&#34;manual-review&#34;" target="reviewOutcome" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_PreApprove" name="Pre-approve">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=true" target="reviewOutcome" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:scriptTask id="Task_CalculateTerm" name="Calculate term">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=42" resultVariable="reviewOutcome" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:serviceTask id="Task_AssessCollateral" name="Assess collateral">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="={ collateralRatio: 2 }" target="reviewOutcome" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_LoanApproval">
+      <bpmndi:BPMNShape id="Task_ScoreApplicant_di" bpmnElement="Task_ScoreApplicant">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_FlagManualReview_di" bpmnElement="Task_FlagManualReview">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_PreApprove_di" bpmnElement="Task_PreApprove">
+        <dc:Bounds x="440" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_CalculateTerm_di" bpmnElement="Task_CalculateTerm">
+        <dc:Bounds x="580" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AssessCollateral_di" bpmnElement="Task_AssessCollateral">
+        <dc:Bounds x="720" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/mappings/merging.same-element.bpmn
+++ b/test/fixtures/zeebe/mappings/merging.same-element.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1f11wk4" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.48.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="Process_CustomerOnboarding" name="Customer onboarding" isExecutable="true">
+    <bpmn:serviceTask id="Task_FetchCustomerProfile" name="Fetch customer profile">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="={ address: { zip: 10115 } }" target="customer" />
+          <zeebe:output source="={ score: 123 }" target="customer.rating" />
+        </zeebe:ioMapping>
+        <zeebe:taskDefinition type="fetch-customer-profile" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17jmw1u</bpmn:incoming>
+    </bpmn:serviceTask>
+    <bpmn:startEvent id="StartEvent_OnboardingRequested" name="Onboarding requested">
+      <bpmn:outgoing>Flow_17jmw1u</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17jmw1u" sourceRef="StartEvent_OnboardingRequested" targetRef="Task_FetchCustomerProfile" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_CustomerOnboarding">
+      <bpmndi:BPMNShape id="Task_FetchCustomerProfile_di" bpmnElement="Task_FetchCustomerProfile">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_OnboardingRequested_di" bpmnElement="StartEvent_OnboardingRequested">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17jmw1u_di" bpmnElement="Flow_17jmw1u">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/zeebe/mappings/merging.same-element.paths.bpmn
+++ b/test/fixtures/zeebe/mappings/merging.same-element.paths.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1f11wk4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="Process_Checkout" name="Checkout" isExecutable="true">
+    <bpmn:serviceTask id="Task_CalculateTotals" name="Calculate totals">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="={ net: 456 }" target="order.pricing" />
+          <zeebe:output source="={ cost: 123 }" target="order.shipping" />
+        </zeebe:ioMapping>
+        <zeebe:taskDefinition type="calculate-totals" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17jmw1u</bpmn:incoming>
+    </bpmn:serviceTask>
+    <bpmn:startEvent id="StartEvent_OrderPlaced" name="Order placed">
+      <bpmn:outgoing>Flow_17jmw1u</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17jmw1u" sourceRef="StartEvent_OrderPlaced" targetRef="Task_CalculateTotals" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_Checkout">
+      <bpmndi:BPMNShape id="Task_CalculateTotals_di" bpmnElement="Task_CalculateTotals">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_OrderPlaced_di" bpmnElement="StartEvent_OrderPlaced">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17jmw1u_di" bpmnElement="Flow_17jmw1u">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/camunda/CamundaVariableResolver.spec.js
+++ b/test/spec/camunda/CamundaVariableResolver.spec.js
@@ -517,6 +517,55 @@ describe('CamundaVariableResolver', function() {
   });
 
 
+  describe('variants', function() {
+
+    beforeEach(
+      bootstrapModeler(simpleXML, {
+        container,
+        additionalModules: [
+          CamundaVariableResolverModule
+        ]
+      })
+    );
+
+
+    it('should expose variants per writing element', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      createProvider({
+        variables: [ { name: 'foo', type: 'String', isList: true, scope: root } ],
+        variableResolver,
+        origin: 'Process_1'
+      });
+      createProvider({
+        variables: [ { name: 'foo', type: 'Number', scope: root } ],
+        variableResolver,
+        origin: 'ServiceTask_1'
+      });
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'foo',
+          type: 'Number|String',
+          isList: 'optional',
+          origin: [ 'Process_1', 'ServiceTask_1' ],
+          variants: [
+            { name: 'foo', type: 'String', isList: true, origin: [ 'Process_1' ] },
+            { name: 'foo', type: 'Number', isList: false, origin: [ 'ServiceTask_1' ] }
+          ]
+        }
+      ]);
+    }));
+
+  });
+
+
   describe('editor compatibility', function() {
 
     beforeEach(

--- a/test/spec/zeebe/Mappings.spec.js
+++ b/test/spec/zeebe/Mappings.spec.js
@@ -355,6 +355,60 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
   });
 
 
+  describe('Merging - variants', function() {
+
+    beforeEach(bootstrap(mergingXML));
+
+
+    it('should split value per writing element', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Participant_2');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root.businessObject.processRef);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'multipleSources',
+          type: 'Context|String',
+          entries: [
+            { name: 'a' },
+            { name: 'b' }
+          ],
+          variants: [
+            {
+              name: 'multipleSources',
+              type: 'Context',
+              origin: [ 'Activity_1p9raox' ],
+              entries: [
+                { name: 'a', type: 'Null' }
+              ]
+            },
+            {
+              name: 'multipleSources',
+              type: 'Context',
+              origin: [ 'Activity_18bm41l' ],
+              entries: [
+                { name: 'b', type: 'Null' }
+              ]
+            },
+            {
+              name: 'multipleSources',
+              type: 'String',
+              info: '"null"',
+              origin: [ 'Activity_1deugon' ],
+              entries: []
+            }
+          ]
+        }
+      ]);
+    }));
+
+  });
+
+
   describe('Merging - null', function() {
 
     beforeEach(bootstrap(mergingNullXML));
@@ -1021,6 +1075,22 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
       const a = variables.find(v => v.name === 'a');
       expect(a).to.exist;
       expect(a.scope).to.not.exist;
+    }));
+
+
+    it('should not expose variants on consumed variables', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('SimpleTask');
+
+      // when
+      const variables = await getReadVariablesForElement(variableResolver, task);
+
+      // then
+      expect(variables).to.variableEqual([
+        { name: 'a', variants: undefined },
+        { name: 'b', variants: undefined }
+      ]);
     }));
 
 

--- a/test/spec/zeebe/Mappings.spec.js
+++ b/test/spec/zeebe/Mappings.spec.js
@@ -18,6 +18,7 @@ import consumedVariablesXML from 'test/fixtures/zeebe/mappings/input-requirement
 import primitivesXML from 'test/fixtures/zeebe/mappings/primitives.bpmn';
 import mergingXML from 'test/fixtures/zeebe/mappings/merging.bpmn';
 import mergingChildrenXML from 'test/fixtures/zeebe/mappings/merging.children.bpmn';
+import mergingPerElementXML from 'test/fixtures/zeebe/mappings/merging.per-element.bpmn';
 import mergingNullXML from 'test/fixtures/zeebe/mappings/merging.null.bpmn';
 import mergingAnyXML from 'test/fixtures/zeebe/mappings/merging.any.bpmn';
 import mergingAnyExpressionsXML from 'test/fixtures/zeebe/mappings/merging.any-expression.bpmn';
@@ -401,6 +402,142 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
               origin: [ 'Activity_1deugon' ],
               entries: []
             }
+          ]
+        }
+      ]);
+    }));
+
+  });
+
+
+  describe('Merging - variants - result expressions', function() {
+
+    beforeEach(bootstrap(mergingPerElementXML));
+
+
+    it('should split value per writing element', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_LoanApproval');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root.businessObject);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'reviewOutcome',
+          type: 'Boolean|Context|Number|String',
+          scope: 'Process_LoanApproval',
+          origin: [ 'Task_ScoreApplicant', 'Task_FlagManualReview', 'Task_PreApprove', 'Task_CalculateTerm', 'Task_AssessCollateral' ],
+          entries: [
+            {
+              name: 'score',
+              type: 'Context',
+              entries: [
+                { name: 'value', type: 'Number', info: '720' }
+              ]
+            },
+            { name: 'collateralRatio', type: 'Number', info: '2' }
+          ],
+          variants: [
+            {
+              name: 'reviewOutcome',
+              type: 'Context',
+              detail: 'Context',
+              origin: [ 'Task_ScoreApplicant' ],
+              entries: [
+                {
+                  name: 'score',
+                  type: 'Context',
+                  entries: [
+                    { name: 'value', type: 'Number', info: '720' }
+                  ]
+                }
+              ]
+            },
+            { name: 'reviewOutcome', type: 'String', detail: 'String', info: '"manual-review"', origin: [ 'Task_FlagManualReview' ] },
+            { name: 'reviewOutcome', type: 'Boolean', info: 'true', origin: [ 'Task_PreApprove' ] },
+            { name: 'reviewOutcome', type: 'Number', info: '42', origin: [ 'Task_CalculateTerm' ] },
+            {
+              name: 'reviewOutcome',
+              type: 'Context',
+              origin: [ 'Task_AssessCollateral' ],
+              entries: [
+                { name: 'collateralRatio', type: 'Number', info: '2' }
+              ]
+            }
+          ]
+        }
+      ]);
+    }));
+
+  });
+
+
+  describe('Merging - variants - uncertain expressions', function() {
+
+    beforeEach(bootstrap(mergingAnyExpressionsXML));
+
+
+    it('should keep value per writing element', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root.businessObject);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'variable',
+          type: 'Any',
+          info: '=unknown\n=alsoUnknown',
+          origin: [ 'Task_7', 'Task_8' ],
+          variants: [
+            { name: 'variable', type: 'Any', detail: 'Any', info: '=unknown', origin: [ 'Task_7' ] },
+            { name: 'variable', type: 'Any', detail: 'Any', info: '=alsoUnknown', origin: [ 'Task_8' ] }
+          ]
+        }
+      ]);
+    }));
+
+  });
+
+
+  describe('Merging - variants - pre-merged origins', function() {
+
+    beforeEach(bootstrap(mergingNullXML));
+
+
+    it('should split value per writing element', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const subProcess = elementRegistry.get('SubProcess_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(subProcess);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'processVariable',
+          type: 'Null|Number',
+          scope: 'Process_4',
+          origin: [ 'SubProcess_1' ],
+          variants: [
+            { name: 'processVariable', type: 'Null|Number', origin: [ 'SubProcess_1' ] }
+          ]
+        },
+        {
+          name: 'localVariable',
+          type: 'Null|Number',
+          scope: 'SubProcess_1',
+          origin: [ 'SubProcess_1', 'Task_6' ],
+          variants: [
+            { name: 'localVariable', type: 'Null', detail: 'Null', origin: [ 'SubProcess_1' ] },
+            { name: 'localVariable', type: 'Number', detail: 'Number', info: '15', origin: [ 'Task_6' ] }
           ]
         }
       ]);

--- a/test/spec/zeebe/Mappings.spec.js
+++ b/test/spec/zeebe/Mappings.spec.js
@@ -19,6 +19,7 @@ import primitivesXML from 'test/fixtures/zeebe/mappings/primitives.bpmn';
 import mergingXML from 'test/fixtures/zeebe/mappings/merging.bpmn';
 import mergingChildrenXML from 'test/fixtures/zeebe/mappings/merging.children.bpmn';
 import mergingPerElementXML from 'test/fixtures/zeebe/mappings/merging.per-element.bpmn';
+import mergingSameElementXML from 'test/fixtures/zeebe/mappings/merging.same-element.bpmn';
 import mergingNullXML from 'test/fixtures/zeebe/mappings/merging.null.bpmn';
 import mergingAnyXML from 'test/fixtures/zeebe/mappings/merging.any.bpmn';
 import mergingAnyExpressionsXML from 'test/fixtures/zeebe/mappings/merging.any-expression.bpmn';
@@ -498,6 +499,72 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
           variants: [
             { name: 'variable', type: 'Any', detail: 'Any', info: '=unknown', origin: [ 'Task_7' ] },
             { name: 'variable', type: 'Any', detail: 'Any', info: '=alsoUnknown', origin: [ 'Task_8' ] }
+          ]
+        }
+      ]);
+    }));
+
+  });
+
+
+  describe('Merging - variants - same-element contributions', function() {
+
+    beforeEach(bootstrap(mergingSameElementXML));
+
+
+    it('should combine contributions into a single variant', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_CustomerOnboarding');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root.businessObject);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'customer',
+          type: 'Context',
+          scope: 'Process_CustomerOnboarding',
+          origin: [ 'Task_FetchCustomerProfile' ],
+          entries: [
+            {
+              name: 'rating',
+              type: 'Context',
+              entries: [
+                { name: 'score', type: 'Number', info: '123' }
+              ]
+            },
+            {
+              name: 'address',
+              type: 'Context',
+              entries: [
+                { name: 'zip', type: 'Number', info: '10115' }
+              ]
+            }
+          ],
+          variants: [
+            {
+              name: 'customer',
+              type: 'Context',
+              origin: [ 'Task_FetchCustomerProfile' ],
+              entries: [
+                {
+                  name: 'rating',
+                  type: 'Context',
+                  entries: [
+                    { name: 'score', type: 'Number', info: '123' }
+                  ]
+                },
+                {
+                  name: 'address',
+                  type: 'Context',
+                  entries: [
+                    { name: 'zip', type: 'Number', info: '10115' }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]);

--- a/test/spec/zeebe/Mappings.spec.js
+++ b/test/spec/zeebe/Mappings.spec.js
@@ -20,6 +20,7 @@ import mergingXML from 'test/fixtures/zeebe/mappings/merging.bpmn';
 import mergingChildrenXML from 'test/fixtures/zeebe/mappings/merging.children.bpmn';
 import mergingPerElementXML from 'test/fixtures/zeebe/mappings/merging.per-element.bpmn';
 import mergingSameElementXML from 'test/fixtures/zeebe/mappings/merging.same-element.bpmn';
+import mergingSameElementPathsXML from 'test/fixtures/zeebe/mappings/merging.same-element.paths.bpmn';
 import mergingNullXML from 'test/fixtures/zeebe/mappings/merging.null.bpmn';
 import mergingAnyXML from 'test/fixtures/zeebe/mappings/merging.any.bpmn';
 import mergingAnyExpressionsXML from 'test/fixtures/zeebe/mappings/merging.any-expression.bpmn';
@@ -561,6 +562,72 @@ describe('ZeebeVariableResolver - Variable Mappings', function() {
                   type: 'Context',
                   entries: [
                     { name: 'zip', type: 'Number', info: '10115' }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+    }));
+
+  });
+
+
+  describe('Merging - variants - same-element path contributions', function() {
+
+    beforeEach(bootstrap(mergingSameElementPathsXML));
+
+
+    it('should combine path-only contributions into a single variant', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_Checkout');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root.businessObject);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'order',
+          type: 'Context',
+          scope: 'Process_Checkout',
+          origin: [ 'Task_CalculateTotals' ],
+          entries: [
+            {
+              name: 'pricing',
+              type: 'Context',
+              entries: [
+                { name: 'net', type: 'Number', info: '456' }
+              ]
+            },
+            {
+              name: 'shipping',
+              type: 'Context',
+              entries: [
+                { name: 'cost', type: 'Number', info: '123' }
+              ]
+            }
+          ],
+          variants: [
+            {
+              name: 'order',
+              type: 'Context',
+              origin: [ 'Task_CalculateTotals' ],
+              entries: [
+                {
+                  name: 'pricing',
+                  type: 'Context',
+                  entries: [
+                    { name: 'net', type: 'Number', info: '456' }
+                  ]
+                },
+                {
+                  name: 'shipping',
+                  type: 'Context',
+                  entries: [
+                    { name: 'cost', type: 'Number', info: '123' }
                   ]
                 }
               ]

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -915,6 +915,76 @@ describe('ZeebeVariableResolver', function() {
       ]);
     }));
 
+
+    it('should keep variants scoped per variable record', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+      const task = elementRegistry.get('ServiceTask_1');
+
+      createProvider({
+        variables: [ { name: 'foo', type: 'String', scope: root } ],
+        variableResolver,
+        origin: 'Process_1'
+      });
+      createProvider({
+        variables: [ {
+          name: 'foo',
+          type: 'Context',
+          scope: task,
+          entries: [
+            { name: 'secret', type: 'Number' }
+          ]
+        } ],
+        variableResolver,
+        origin: 'ServiceTask_1'
+      });
+
+      // when
+      const variables = await variableResolver.getProcessVariables(root);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'foo',
+          type: 'String',
+          scope: 'Process_1',
+          origin: [ 'Process_1' ],
+          variants: [
+            {
+              name: 'foo',
+              type: 'String',
+              scope: 'Process_1',
+              origin: [ 'Process_1' ]
+            }
+          ]
+        },
+        {
+          name: 'foo',
+          type: 'Context',
+          scope: 'ServiceTask_1',
+          origin: [ 'ServiceTask_1' ],
+          variants: [
+            {
+              name: 'foo',
+              type: 'Context',
+              scope: 'ServiceTask_1',
+              origin: [ 'ServiceTask_1' ],
+              entries: [
+                { name: 'secret', type: 'Number' }
+              ]
+            }
+          ]
+        }
+      ]);
+
+      const rootRecord = variables.find(v => v.name === 'foo' && v.scope.id === 'Process_1');
+
+      expect(rootRecord.variants).to.have.lengthOf(1);
+      expect(rootRecord.variants[0].entries).not.to.exist;
+      expect(rootRecord.variants[0].scope.id).to.eql('Process_1');
+    }));
+
   });
 
 

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -916,6 +916,39 @@ describe('ZeebeVariableResolver', function() {
     }));
 
 
+    it('should combine contributions of same element', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      createProvider({
+        variables: [ { name: 'foo', type: 'String', scope: root } ],
+        variableResolver,
+        origin: 'ServiceTask_1'
+      });
+      createProvider({
+        variables: [ { name: 'foo', type: 'Number', scope: root } ],
+        variableResolver,
+        origin: 'ServiceTask_1'
+      });
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'foo',
+          type: 'Number|String',
+          origin: [ 'ServiceTask_1' ],
+          variants: [
+            { name: 'foo', type: 'Number|String', origin: [ 'ServiceTask_1' ] }
+          ]
+        }
+      ]);
+    }));
+
+
     it('should keep variants scoped per variable record', inject(async function(variableResolver, elementRegistry) {
 
       // given

--- a/test/spec/zeebe/ZeebeVariableResolver.spec.js
+++ b/test/spec/zeebe/ZeebeVariableResolver.spec.js
@@ -692,6 +692,232 @@ describe('ZeebeVariableResolver', function() {
   });
 
 
+  describe('variants', function() {
+
+    beforeEach(
+      bootstrapModeler(simpleXML, {
+        additionalModules: [
+          ZeebeVariableResolverModule
+        ]
+      })
+    );
+
+
+    it('should expose per-writer variants', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      createProvider({
+        variables: [ { name: 'foo', type: 'String', scope: root } ],
+        variableResolver,
+        origin: 'Process_1'
+      });
+      createProvider({
+        variables: [ {
+          name: 'foo',
+          type: 'Context',
+          scope: root,
+          entries: [
+            { name: 'bar', type: 'Number' }
+          ]
+        } ],
+        variableResolver,
+        origin: 'ServiceTask_1'
+      });
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'foo',
+          type: 'Context|String',
+          scope: 'Process_1',
+          origin: [ 'Process_1', 'ServiceTask_1' ],
+          entries: [
+            { name: 'bar', type: 'Number' }
+          ],
+          variants: [
+            {
+              name: 'foo',
+              type: 'String',
+              scope: 'Process_1',
+              origin: [ 'Process_1' ]
+            },
+            {
+              name: 'foo',
+              type: 'Context',
+              scope: 'Process_1',
+              origin: [ 'ServiceTask_1' ],
+              entries: [
+                { name: 'bar', type: 'Number' }
+              ]
+            }
+          ]
+        }
+      ]);
+    }));
+
+
+    it('should not leak entries between variants', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      createProvider({
+        variables: [ { name: 'foo', type: 'String', scope: root } ],
+        variableResolver,
+        origin: 'Process_1'
+      });
+      createProvider({
+        variables: [ {
+          name: 'foo',
+          type: 'Context',
+          scope: root,
+          entries: [
+            { name: 'bar', type: 'Number' }
+          ]
+        } ],
+        variableResolver,
+        origin: 'ServiceTask_1'
+      });
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root);
+
+      // then
+      const stringVariant = variables[0].variants.find(v => v.origin[0].id === 'Process_1');
+
+      expect(stringVariant.entries).not.to.exist;
+    }));
+
+
+    it('should expose one variant per writer', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      createProvider({
+        variables: [ { name: 'foo', type: 'String', scope: root } ],
+        variableResolver,
+        origin: 'Process_1'
+      });
+      createProvider({
+        variables: [ { name: 'foo', type: 'Number', scope: root } ],
+        variableResolver,
+        origin: 'ServiceTask_1'
+      });
+      createProvider({
+        variables: [ { name: 'foo', type: 'Boolean', scope: root } ],
+        variableResolver,
+        origin: 'ServiceTask_2'
+      });
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'foo',
+          type: 'Boolean|Number|String',
+          scope: 'Process_1',
+          origin: [ 'Process_1', 'ServiceTask_1', 'ServiceTask_2' ],
+          variants: [
+            { name: 'foo', type: 'String', origin: [ 'Process_1' ] },
+            { name: 'foo', type: 'Number', origin: [ 'ServiceTask_1' ] },
+            { name: 'foo', type: 'Boolean', origin: [ 'ServiceTask_2' ] }
+          ]
+        }
+      ]);
+    }));
+
+
+    it('should expose single variant for single writer', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      createProvider({
+        variables: [ { name: 'foo', type: 'String', scope: root } ],
+        variableResolver,
+        origin: 'Process_1'
+      });
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'foo',
+          type: 'String',
+          scope: 'Process_1',
+          origin: [ 'Process_1' ],
+          variants: [
+            { name: 'foo', type: 'String', detail: 'String', scope: 'Process_1', origin: [ 'Process_1' ] }
+          ]
+        }
+      ]);
+    }));
+
+
+    it('should split hierarchical variables per writer', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      createProvider({
+        variables: [ { name: 'foo.bar', type: 'String', scope: root } ],
+        variableResolver,
+        origin: 'Process_1'
+      });
+      createProvider({
+        variables: [ { name: 'foo.woop', type: 'String', scope: root } ],
+        variableResolver,
+        origin: 'ServiceTask_1'
+      });
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'foo',
+          type: 'Context',
+          scope: 'Process_1',
+          entries: [
+            { name: 'bar', type: 'String' },
+            { name: 'woop', type: 'String' }
+          ],
+          variants: [
+            {
+              name: 'foo',
+              type: 'Context',
+              origin: [ 'Process_1' ],
+              entries: [
+                { name: 'bar', type: 'String' }
+              ]
+            },
+            {
+              name: 'foo',
+              type: 'Context',
+              origin: [ 'ServiceTask_1' ],
+              entries: [
+                { name: 'woop', type: 'String' }
+              ]
+            }
+          ]
+        }
+      ]);
+    }));
+
+  });
+
+
   describe('hierarchical names', function() {
 
     beforeEach(
@@ -1159,6 +1385,40 @@ describe('ZeebeVariableResolver', function() {
       // own variables
       expect(variables).to.variableEqual([
         { name: 'variable4', origin: [ 'Task_3', 'SubProcess_2' ], scope: 'Process_1' }
+      ]);
+    }));
+
+
+    it('should split pre-merged multi-origin variable per writer', inject(async function(variableResolver, elementRegistry) {
+
+      // given
+      const root = elementRegistry.get('Process_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(root);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'variable4',
+          origin: [ 'Task_3', 'SubProcess_2' ],
+          scope: 'Process_1',
+          variants: [
+            {
+              name: 'variable4',
+              type: 'Number',
+              info: '1',
+              scope: 'Process_1',
+              origin: [ 'Task_3' ]
+            },
+            {
+              name: 'variable4',
+              type: 'Any',
+              scope: 'Process_1',
+              origin: [ 'SubProcess_2' ]
+            }
+          ]
+        }
       ]);
     }));
 


### PR DESCRIPTION
### Proposed Changes

This pull request aims to introduce a `variants` property per variable per origin so that individual incarnations of variable writes can be visualized in the user interface.

I have aimed to;

- non-breaking changes, only additive
- stick to existing variable contract as a variant
- merged representation is not altered or removed so that we can stick to the existing autocomplete for feel-editor or possibly other downstreams.  

This pull request should enable `@bpmn-io/variable-outline` to visualize variable incarnations individually rather than merged.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9292da71-c72b-430b-badd-b6913f6ebf34" />

This screenshot is subject to iteration. However, you are welcome to share feedback!

The variable-outline branch is not there yet. It'll be linked here once it's created.

Related to https://github.com/camunda/camunda-modeler/issues/5985

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
